### PR TITLE
Legger til endepunkt for oppslag av spesifikke orgnummere mot enhetsregisteret

### DIFF
--- a/fail_env
+++ b/fail_env
@@ -1,6 +1,5 @@
 export LOGIN_SERVICE_V1_DISCOVERY_ENDPOINT=https://login.microsoftonline.com/NAVtestB2C.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=B2C_1A_idporten_ver1
 
-export AKTOER_V1_URL=http://localhost:8082
 export ARBEIDSGIVER_OG_ARBEIDSTAKER_V1_URL=http://localhost:8083
 export ENHET_V1_URL=http://localhost:8084
 export TPS_PROXY_V1_URL=http://localhost:8085

--- a/nais/dev-fss.json
+++ b/nais/dev-fss.json
@@ -13,7 +13,6 @@
   "env": {
     "LOGIN_SERVICE_V1_DISCOVERY_ENDPOINT": "https://login.microsoftonline.com/NAVtestB2C.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=B2C_1A_idporten_ver1",
     "ARBEIDSGIVER_OG_ARBEIDSTAKER_V1_URL": "https://modapp-q1.adeo.no/aareg-services/api/v1",
-    "AKTOER_V1_URL": "https://app-q1.adeo.no/aktoerregister/api/v1",
     "ENHET_V1_URL": "https://modapp-q1.adeo.no/ereg/api/v1/",
     "REST_TOKEN_URL": "https://security-token-service.nais.preprod.local/rest/v1/sts/token",
     "TPS_PROXY_V1_URL": "https://tps-proxy-q1.nais.preprod.local/api/v1",

--- a/nais/prod-fss.json
+++ b/nais/prod-fss.json
@@ -13,7 +13,6 @@
   "env": {
     "LOGIN_SERVICE_V1_DISCOVERY_ENDPOINT": "https://login.microsoftonline.com/navnob2c.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=B2C_1A_idporten",
     "ARBEIDSGIVER_OG_ARBEIDSTAKER_V1_URL": "https://modapp.adeo.no/aareg-services/api/v1",
-    "AKTOER_V1_URL": "https://app.adeo.no/aktoerregister/api/v1",
     "ENHET_V1_URL": "https://modapp.adeo.no/ereg/api/v1/",
     "REST_TOKEN_URL": "https://security-token-service.nais.adeo.no/rest/v1/sts/token",
     "TPS_PROXY_V1_URL": "https://tps-proxy.nais.adeo.no/api/v1",

--- a/src/main/kotlin/no/nav/k9/inngaende/oppslag/ArbeidsgivereOppslag.kt
+++ b/src/main/kotlin/no/nav/k9/inngaende/oppslag/ArbeidsgivereOppslag.kt
@@ -2,15 +2,16 @@ package no.nav.k9.inngaende.oppslag
 
 import no.nav.k9.utgaende.gateway.EnhetsregisterV1Gateway
 import no.nav.k9.utgaende.rest.Arbeidsforhold
+import java.time.LocalDate
 
 internal class ArbeidsgivereOppslag(
-    private val enhetsregisterV1Gateway: EnhetsregisterV1Gateway
+    private val enhetsregisterV1Gateway: EnhetsregisterV1Gateway,
 ) {
 
     internal suspend fun organisasjoner(
         attributter: Set<Attributt>,
-        arbeidsforhold: Arbeidsforhold?
-    ) : Set<ArbeidsgiverOrganisasjon>? {
+        arbeidsforhold: Arbeidsforhold?,
+    ): Set<ArbeidsgiverOrganisasjon>? {
 
         if (!attributter.etterspurtArbeidsgibereOrganaisasjoner()) return null
 
@@ -20,7 +21,9 @@ internal class ArbeidsgivereOppslag(
                 navn = hentNavn(
                     organisasjonsnummer = it.organisasjonsnummer,
                     attributter = attributter
-                )
+                ),
+                ansattFom = it.ansattFom,
+                ansattTom = it.ansattTom
             )
         }.toSet()
 
@@ -28,7 +31,7 @@ internal class ArbeidsgivereOppslag(
 
     private suspend fun hentNavn(
         organisasjonsnummer: String,
-        attributter: Set<Attributt>
+        attributter: Set<Attributt>,
     ) = try {
         enhetsregisterV1Gateway.enhet(
             attributter = attributter,
@@ -41,5 +44,7 @@ internal class ArbeidsgivereOppslag(
 
 internal data class ArbeidsgiverOrganisasjon(
     internal val organisasjonsnummer: String,
-    internal val navn: String?
+    internal val navn: String?,
+    internal val ansattFom: LocalDate? = null,
+    internal val ansattTom: LocalDate? = null,
 )

--- a/src/main/kotlin/no/nav/k9/inngaende/oppslag/Domene.kt
+++ b/src/main/kotlin/no/nav/k9/inngaende/oppslag/Domene.kt
@@ -20,6 +20,7 @@ internal enum class Attributt(internal val api: String) {
 
     arbeidsgivereOrganisasjonerNavn("arbeidsgivere[].organisasjoner[].navn"),
     arbeidsgivereOrganisasjonerOrganisasjonsnummer("arbeidsgivere[].organisasjoner[].organisasjonsnummer"),
+    arbeidsgivereOrganisasjonerAnsettelsesperiode("arbeidsgivere[].organisasjoner[].ansettelsesperiode"),
 
     personligForetakOrganisasjonsnummer("personlige_foretak[].organisasjonsnummer"),
     personligForetakNavn("personlige_foretak[].navn"),

--- a/src/main/kotlin/no/nav/k9/inngaende/oppslag/Domene.kt
+++ b/src/main/kotlin/no/nav/k9/inngaende/oppslag/Domene.kt
@@ -57,8 +57,8 @@ private val megAttributter = setOf(
 internal fun Set<Attributt>.etterspurtMeg() = any { it in megAttributter }
 
 internal data class OppslagResultat(
-    internal val meg: Meg?,
-    internal val barn: Set<Barn>?,
-    internal val arbeidsgivereOrganisasjoner: Set<ArbeidsgiverOrganisasjon>?,
-    internal val personligeForetak: Set<PersonligForetak<String>>?
+    internal val meg: Meg? = null,
+    internal val barn: Set<Barn>? = null,
+    internal val arbeidsgivereOrganisasjoner: Set<ArbeidsgiverOrganisasjon>? = null,
+    internal val personligeForetak: Set<PersonligForetak<String>>? = null
 )

--- a/src/main/kotlin/no/nav/k9/inngaende/oppslag/Json.kt
+++ b/src/main/kotlin/no/nav/k9/inngaende/oppslag/Json.kt
@@ -42,8 +42,8 @@ internal fun OppslagResultat.somJson(attributter: Set<Attributt>) : JSONObject {
                 if (attributter.contains(Attributt.arbeidsgivereOrganisasjonerOrganisasjonsnummer)) put("organisasjonsnummer", it.organisasjonsnummer)
                 if (attributter.contains(Attributt.arbeidsgivereOrganisasjonerNavn)) put("navn", it.navn)
                 if (attributter.contains(Attributt.arbeidsgivereOrganisasjonerAnsettelsesperiode)) {
-                    put("ansattFom", it.ansattFom)
-                    put("ansattTom", it.ansattTom)
+                    put("ansatt_fom", it.ansattFom)
+                    put("ansatt_tom", it.ansattTom)
                 }
             })
         }

--- a/src/main/kotlin/no/nav/k9/inngaende/oppslag/Json.kt
+++ b/src/main/kotlin/no/nav/k9/inngaende/oppslag/Json.kt
@@ -41,6 +41,10 @@ internal fun OppslagResultat.somJson(attributter: Set<Attributt>) : JSONObject {
             organisasjonerJson.put(JSONObject().apply {
                 if (attributter.contains(Attributt.arbeidsgivereOrganisasjonerOrganisasjonsnummer)) put("organisasjonsnummer", it.organisasjonsnummer)
                 if (attributter.contains(Attributt.arbeidsgivereOrganisasjonerNavn)) put("navn", it.navn)
+                if (attributter.contains(Attributt.arbeidsgivereOrganisasjonerAnsettelsesperiode)) {
+                    put("ansattFom", it.ansattFom)
+                    put("ansattTom", it.ansattTom)
+                }
             })
         }
         arbeidsgivereJson.put("organisasjoner", organisasjonerJson)

--- a/src/main/kotlin/no/nav/k9/inngaende/oppslag/OppslagService.kt
+++ b/src/main/kotlin/no/nav/k9/inngaende/oppslag/OppslagService.kt
@@ -1,14 +1,14 @@
 package no.nav.k9.inngaende.oppslag
 
-import io.ktor.util.*
 import no.nav.k9.utgaende.gateway.*
-import no.nav.k9.utgaende.gateway.ArbeidsgiverOgArbeidstakerRegisterV1Gateway
+import no.nav.k9.utgaende.rest.Arbeidsforhold
+import no.nav.k9.utgaende.rest.OrganisasjonArbeidsforhold
 import java.time.LocalDate
 
 
 internal class OppslagService(
     private val arbeidsgiverOgArbeidstakerRegisterV1Gateway: ArbeidsgiverOgArbeidstakerRegisterV1Gateway,
-    enhetsregisterV1Gateway: EnhetsregisterV1Gateway,
+    private val enhetsregisterV1Gateway: EnhetsregisterV1Gateway,
     tpsProxyV1Gateway: TpsProxyV1Gateway,
     brregProxyV1Gateway: BrregProxyV1Gateway,
     pdlProxyGateway: PDLProxyGateway,
@@ -88,6 +88,25 @@ internal class OppslagService(
             personligeForetak = personligeForetakOppslag.personligeForetak(
                 ident = ident,
                 attributter = attributter
+            )
+        )
+    }
+
+    internal suspend fun arbeidsgivere(
+        attributter: Set<Attributt>,
+        organisasjoner: Set<String>,
+    ): OppslagResultat {
+
+        val arbeidsforhold = Arbeidsforhold(
+            organisasjoner = organisasjoner
+                .map { OrganisasjonArbeidsforhold(it) }
+                .toSet()
+        )
+
+        return OppslagResultat(
+            arbeidsgivereOrganisasjoner = arbeidsgiverOppslag.organisasjoner(
+                attributter = attributter,
+                arbeidsforhold = arbeidsforhold
             )
         )
     }

--- a/src/main/kotlin/no/nav/k9/utgaende/rest/ArbeidsgiverOgArbeidstakerRegisterV1.kt
+++ b/src/main/kotlin/no/nav/k9/utgaende/rest/ArbeidsgiverOgArbeidstakerRegisterV1.kt
@@ -100,8 +100,16 @@ internal class ArbeidsgiverOgArbeidstakerRegisterV1 (
             .map { it as JSONObject }
             .filter { it.has("arbeidsgiver") }
             .filter { it.getJSONObject("arbeidsgiver").has("organisasjonsnummer") }
-            .map { OrganisasjonArbeidsforhold(
-                organisasjonsnummer = it.getJSONObject("arbeidsgiver").getString("organisasjonsnummer")
+            .filter { it.has("ansettelsesperiode") && it.getJSONObject("ansettelsesperiode").has("periode") }
+            .map { ansettelsesforhold ->
+                val organisasjonsnummer = ansettelsesforhold.getJSONObject("arbeidsgiver").getString("organisasjonsnummer")
+                val ansettelsesperiode = ansettelsesforhold.getJSONObject("ansettelsesperiode").getJSONObject("periode")
+                val ansattFom = ansettelsesperiode.getString("fom")
+                val ansattTom = ansettelsesperiode.getStringOrNull("tom")
+                OrganisasjonArbeidsforhold(
+                organisasjonsnummer = organisasjonsnummer,
+                ansattFom = LocalDate.parse(ansattFom),
+                ansattTom = ansattTom?.let { LocalDate.parse(it) }
             )}
             .toSet()
 
@@ -112,7 +120,9 @@ internal class ArbeidsgiverOgArbeidstakerRegisterV1 (
 }
 
 internal data class OrganisasjonArbeidsforhold(
-    internal val organisasjonsnummer: String
+    internal val organisasjonsnummer: String,
+    internal val ansattFom: LocalDate? = null,
+    internal val ansattTom: LocalDate? = null
 )
 internal data class Arbeidsforhold(
     internal val organisasjoner: Set<OrganisasjonArbeidsforhold>

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -13,8 +13,6 @@ nav {
     register_urls {
         tps_proxy_v1 = ""
         tps_proxy_v1 = ${?TPS_PROXY_V1_URL}
-        aktoer_v1 = ""
-        aktoer_v1 = ${?AKTOER_V1_URL}
         arbeidsgiver_og_arbeidstaker_v1 = ""
         arbeidsgiver_og_arbeidstaker_v1 = ${?ARBEIDSGIVER_OG_ARBEIDSTAKER_V1_URL}
         enhetsregister_v1 = ""

--- a/src/test/kotlin/no/nav/k9/ApplicationTest.kt
+++ b/src/test/kotlin/no/nav/k9/ApplicationTest.kt
@@ -427,6 +427,102 @@ class ApplicationTest {
     }
 
     @Test
+    fun `Forvent organiasjon uten navn, gitt at navn ikke er funnet`() {
+        val idToken: String = LoginService.V1_0.generateJwt(PERSON_1_MED_BARN)
+        with(engine) {
+            handleRequest(
+                HttpMethod.Get,
+                "/arbeidsgivere?a=arbeidsgivere[].organisasjoner[].organisasjonsnummer&a=arbeidsgivere[].organisasjoner[].navn&org=11111111"
+            ) {
+                addHeader(HttpHeaders.Authorization, "Bearer $idToken")
+                addHeader(HttpHeaders.XCorrelationId, "arbeidsgiver-oppslag-orgnr-navn")
+            }.apply {
+                assertEquals(HttpStatusCode.OK, response.status())
+                assertEquals("application/json; charset=UTF-8", response.contentType().toString())
+                //language=json
+                val expectedResponse = """
+            {
+                "arbeidsgivere": {
+                    "organisasjoner": [
+                        {
+                            "organisasjonsnummer": "11111111"
+                        }
+                    ]
+                }
+             }
+            """.trimIndent()
+                JSONAssert.assertEquals(expectedResponse, response.content!!, true)
+            }
+        }
+    }
+
+    @Test
+    fun `Forvent 1 organisasjon med navn, gitt organisasjonsnummer`() {
+        val idToken: String = LoginService.V1_0.generateJwt(PERSON_1_MED_BARN)
+        with(engine) {
+            handleRequest(
+                HttpMethod.Get,
+                "/arbeidsgivere?a=arbeidsgivere[].organisasjoner[].organisasjonsnummer&a=arbeidsgivere[].organisasjoner[].navn&org=981585216"
+            ) {
+                addHeader(HttpHeaders.Authorization, "Bearer $idToken")
+                addHeader(HttpHeaders.XCorrelationId, "arbeidsgiver-oppslag-orgnr-navn")
+            }.apply {
+                assertEquals(HttpStatusCode.OK, response.status())
+                assertEquals("application/json; charset=UTF-8", response.contentType().toString())
+                //language=json
+                val expectedResponse = """
+            {
+                "arbeidsgivere": {
+                    "organisasjoner": [
+                        {
+                            "organisasjonsnummer": "981585216",
+                            "navn": "NAV FAMILIE- OG PENSJONSYTELSER"
+                        }
+                    ]
+                }
+             }
+            """.trimIndent()
+                JSONAssert.assertEquals(expectedResponse, response.content!!, true)
+            }
+        }
+    }
+
+    @Test
+    fun `Forvent 2 organisasjoner med navn, gitt organisasjonsnummer`() {
+        val idToken: String = LoginService.V1_0.generateJwt(PERSON_1_MED_BARN)
+        with(engine) {
+            handleRequest(
+                HttpMethod.Get,
+                "/arbeidsgivere?a=arbeidsgivere[].organisasjoner[].organisasjonsnummer&a=arbeidsgivere[].organisasjoner[].navn&org=981585216&org=67564534"
+            ) {
+                addHeader(HttpHeaders.Authorization, "Bearer $idToken")
+                addHeader(HttpHeaders.XCorrelationId, "arbeidsgiver-oppslag-orgnr-navn")
+            }.apply {
+                assertEquals(HttpStatusCode.OK, response.status())
+                assertEquals("application/json; charset=UTF-8", response.contentType().toString())
+                //language=json
+                val expectedResponse = """
+            {
+                "arbeidsgivere": {
+                    "organisasjoner": [
+                        {
+                            "organisasjonsnummer": "981585216",
+                            "navn": "NAV FAMILIE- OG PENSJONSYTELSER"
+                        },
+                        {
+                            "organisasjonsnummer": "67564534",
+                            "navn": "SELSKAP, MED, VELDIG, MANGE, NAVNELINJER"
+                        }
+                    ]
+                }
+             }
+            """.trimIndent()
+                JSONAssert.assertEquals(expectedResponse, response.content!!, true)
+            }
+        }
+    }
+
+    @Test
     fun `test arbeidsgiverOppslag orgnr, navn, fom og tom`() {
         val idToken: String = LoginService.V1_0.generateJwt(PERSON_1_MED_BARN)
         with(engine) {

--- a/src/test/kotlin/no/nav/k9/ApplicationTest.kt
+++ b/src/test/kotlin/no/nav/k9/ApplicationTest.kt
@@ -528,29 +528,33 @@ class ApplicationTest {
         with(engine) {
             handleRequest(
                 HttpMethod.Get,
-                "/meg?fom=2019-02-02&tom=2019-10-10&a=arbeidsgivere[].organisasjoner[].organisasjonsnummer&a=arbeidsgivere[].organisasjoner[].navn"
+                "/meg?fom=2019-02-02&tom=2019-10-10&a=arbeidsgivere[].organisasjoner[].organisasjonsnummer&a=arbeidsgivere[].organisasjoner[].navn&a=arbeidsgivere[].organisasjoner[].ansettelsesperiode"
             ) {
                 addHeader(HttpHeaders.Authorization, "Bearer $idToken")
                 addHeader(HttpHeaders.XCorrelationId, "arbeidsgiver-oppslag-orgnr-navn")
             }.apply {
                 assertEquals(HttpStatusCode.OK, response.status())
                 assertEquals("application/json; charset=UTF-8", response.contentType().toString())
+                //language=json
                 val expectedResponse = """
-            {
-                "arbeidsgivere": {
-                    "organisasjoner": [
-                        {
-                            "organisasjonsnummer": "123456789",
-                            "navn": "DNB, FORSIKRING"
-                        },
-                        {
-                            "organisasjonsnummer": "981585216",
-                            "navn": "NAV FAMILIE- OG PENSJONSYTELSER"
-                        }
-                    ]
-                }
-             }
-            """.trimIndent()
+                {
+                    "arbeidsgivere": {
+                        "organisasjoner": [
+                            {
+                                "organisasjonsnummer": "123456789",
+                                "navn": "DNB, FORSIKRING",
+                                "ansattFom": "2014-07-01",
+                                "ansattTom": "2015-12-31"
+                            },
+                            {
+                                "organisasjonsnummer": "981585216",
+                                "navn": "NAV FAMILIE- OG PENSJONSYTELSER",
+                                "ansattFom": "2000-04-24"
+                            }
+                        ]
+                    }
+                 }
+                """.trimIndent()
                 JSONAssert.assertEquals(expectedResponse, response.content!!, true)
             }
         }

--- a/src/test/kotlin/no/nav/k9/ApplicationTest.kt
+++ b/src/test/kotlin/no/nav/k9/ApplicationTest.kt
@@ -543,13 +543,13 @@ class ApplicationTest {
                             {
                                 "organisasjonsnummer": "123456789",
                                 "navn": "DNB, FORSIKRING",
-                                "ansattFom": "2014-07-01",
-                                "ansattTom": "2015-12-31"
+                                "ansatt_fom": "2014-07-01",
+                                "ansatt_tom": "2015-12-31"
                             },
                             {
                                 "organisasjonsnummer": "981585216",
                                 "navn": "NAV FAMILIE- OG PENSJONSYTELSER",
-                                "ansattFom": "2000-04-24"
+                                "ansatt_fom": "2000-04-24"
                             }
                         ]
                     }

--- a/src/test/kotlin/no/nav/k9/TestConfiguration.kt
+++ b/src/test/kotlin/no/nav/k9/TestConfiguration.kt
@@ -15,7 +15,6 @@ object TestConfiguration {
     fun asMap(
         wireMockServer: WireMockServer? = null,
         port : Int = 8080,
-        aktoerRegisterBaseUrl : String? = wireMockServer?.getAktoerRegisterUrl(),
         arbeidsgiverOgArbeidstakerRegisterBaseUrl : String? = wireMockServer?.getArbeidsgiverOgArbeidstakerRegisterUrl(),
         enhetsRegisterBaseUrl : String? = wireMockServer?.getEnhetsregisterUrl(),
         brregProxyV1BaseUrl : String? = wireMockServer?.getBrregProxyV1BaseUrl(),
@@ -28,7 +27,6 @@ object TestConfiguration {
             Pair("ktor.deployment.port","$port"),
 
             Pair("nav.register_urls.tps_proxy_v1", "$tpsProxyBaseUrl"),
-            Pair("nav.register_urls.aktoer_v1", "$aktoerRegisterBaseUrl"),
             Pair("nav.register_urls.arbeidsgiver_og_arbeidstaker_v1", "$arbeidsgiverOgArbeidstakerRegisterBaseUrl"),
             Pair("nav.register_urls.enhetsregister_v1", "$enhetsRegisterBaseUrl"),
             Pair("nav.register_urls.brreg_proxy_v1", "$brregProxyV1BaseUrl"),

--- a/src/test/kotlin/no/nav/k9/wiremocks/ArbeidstakerResponseTransformer.kt
+++ b/src/test/kotlin/no/nav/k9/wiremocks/ArbeidstakerResponseTransformer.kt
@@ -33,225 +33,227 @@ class ArbeidstakerResponseTransformer : ResponseTransformer() {
 private fun getResponse(navIdent: String) : String {
     when (navIdent) {
         "01019012345" -> {
+            //language=json
         return """
             [
-  {
-    "ansettelsesperiode": {
-      "bruksperiode": {
-        "fom": "2015-01-06T21:44:04.748",
-        "tom": "2015-12-06T19:45:04"
-      },
-      "periode": {
-        "fom": "2014-07-01",
-        "tom": "2015-12-31"
-      },
-      "sporingsinformasjon": {
-        "endretAv": "Z990693",
-        "endretKilde": "AAREG",
-        "endretKildereferanse": "referanse-fra-kilde",
-        "endretTidspunkt": "2018-09-19T12:11:20.79",
-        "opprettetAv": "srvappserver",
-        "opprettetKilde": "EDAG",
-        "opprettetKildereferanse": "22a26849-aeef-4b81-9174-e238c11e1081",
-        "opprettetTidspunkt": "2018-09-19T12:10:58.059"
-      },
-      "varslingskode": "ERKONK"
-    },
-    "antallTimerForTimeloennet": [
-      {
-        "antallTimer": 37.5,
-        "periode": {
-          "fom": "2014-07-01",
-          "tom": "2015-12-31"
-        },
-        "rapporteringsperiode": "2018-05",
-        "sporingsinformasjon": {
-          "endretAv": "Z990693",
-          "endretKilde": "AAREG",
-          "endretKildereferanse": "referanse-fra-kilde",
-          "endretTidspunkt": "2018-09-19T12:11:20.79",
-          "opprettetAv": "srvappserver",
-          "opprettetKilde": "EDAG",
-          "opprettetKildereferanse": "22a26849-aeef-4b81-9174-e238c11e1081",
-          "opprettetTidspunkt": "2018-09-19T12:10:58.059"
-        }
-      }
-    ],
-    "arbeidsavtaler": [
-      {
-        "antallTimerPrUke": 37.5,
-        "arbeidstidsordning": "ikkeSkift",
-        "beregnetAntallTimerPrUke": 37.5,
-        "bruksperiode": {
-          "fom": "2015-01-06T21:44:04.748",
-          "tom": "2015-12-06T19:45:04"
-        },
-        "gyldighetsperiode": {
-          "fom": "2014-07-01",
-          "tom": "2015-12-31"
-        },
-        "sistLoennsendring": "string",
-        "sistStillingsendring": "string",
-        "sporingsinformasjon": {
-          "endretAv": "Z990693",
-          "endretKilde": "AAREG",
-          "endretKildereferanse": "referanse-fra-kilde",
-          "endretTidspunkt": "2018-09-19T12:11:20.79",
-          "opprettetAv": "srvappserver",
-          "opprettetKilde": "EDAG",
-          "opprettetKildereferanse": "22a26849-aeef-4b81-9174-e238c11e1081",
-          "opprettetTidspunkt": "2018-09-19T12:10:58.059"
-        },
-        "stillingsprosent": 49.5,
-        "yrke": 2130123
-      }
-    ],
-    "arbeidsforholdId": "abc-321",
-    "arbeidsgiver": {
-      "organisasjonsnummer": "123456789",
-      "type": "DuplikatKey",
-      "type": "Organisasjon"
-    },
-    "arbeidstaker": {
-      "type": "Person",
-      "aktoerId": 1234567890,
-      "offentligIdent": 31126700000
-    },
-    "innrapportertEtterAOrdningen": true,
-    "navArbeidsforholdId": 123456,
-    "opplysningspliktig": {
-      "type": "Organisasjon"
-    },
-    "permisjonPermitteringer": [
-      {
-        "periode": {
-          "fom": "2014-07-01",
-          "tom": "2015-12-31"
-        },
-        "permisjonPermitteringId": "123-xyz",
-        "prosent": 50.5,
-        "sporingsinformasjon": {
-          "endretAv": "Z990693",
-          "endretKilde": "AAREG",
-          "endretKildereferanse": "referanse-fra-kilde",
-          "endretTidspunkt": "2018-09-19T12:11:20.79",
-          "opprettetAv": "srvappserver",
-          "opprettetKilde": "EDAG",
-          "opprettetKildereferanse": "22a26849-aeef-4b81-9174-e238c11e1081",
-          "opprettetTidspunkt": "2018-09-19T12:10:58.059"
-        },
-        "type": "permisjonMedForeldrepenger"
-      }
-    ],
-    "registrert": "2018-09-18T11:12:29",
-    "sistBekreftet": "2018-09-19T12:10:31",
-    "sporingsinformasjon": {
-      "endretAv": "Z990693",
-      "endretKilde": "AAREG",
-      "endretKildereferanse": "referanse-fra-kilde",
-      "endretTidspunkt": "2018-09-19T12:11:20.79",
-      "opprettetAv": "srvappserver",
-      "opprettetKilde": "EDAG",
-      "opprettetKildereferanse": "22a26849-aeef-4b81-9174-e238c11e1081",
-      "opprettetTidspunkt": "2018-09-19T12:10:58.059"
-    },
-    "type": "ordinaertArbeidsforhold",
-    "utenlandsopphold": [
-      {
-        "landkode": "JPN",
-        "periode": {
-          "fom": "2014-07-01",
-          "tom": "2015-12-31"
-        },
-        "rapporteringsperiode": "2017-12",
-        "sporingsinformasjon": {
-          "endretAv": "Z990693",
-          "endretKilde": "AAREG",
-          "endretKildereferanse": "referanse-fra-kilde",
-          "endretTidspunkt": "2018-09-19T12:11:20.79",
-          "opprettetAv": "srvappserver",
-          "opprettetKilde": "EDAG",
-          "opprettetKildereferanse": "22a26849-aeef-4b81-9174-e238c11e1081",
-          "opprettetTidspunkt": "2018-09-19T12:10:58.059"
-        }
-      }
-    ]
-  },
-  
-  {
-    "ansettelsesperiode": {
-        "bruksperiode": {
-            "fom": "2015-08-13T10:19:33.697"
-        },
-        "sporingsinformasjon": {
-            "opprettetKilde": "EDAG",
-            "endretAv": "srvappserver",
-            "opprettetKildereferanse": "9c1857a0-f20a-4d56-8c12-14e32ca2eb62",
-            "opprettetTidspunkt": "2015-08-13T10:19:33.697",
-            "opprettetAv": "srvappserver",
-            "endretKilde": "EDAG",
-            "endretKildereferanse": "9c1857a0-f20a-4d56-8c12-14e32ca2eb62",
-            "endretTidspunkt": "2015-08-13T10:19:33.697"
-        },
-        "periode": {
-            "fom": "2000-04-24"
-        }
-    },
-    "sporingsinformasjon": {
-        "opprettetKilde": "EDAG",
-        "endretAv": "srvappserver",
-        "opprettetKildereferanse": "5eab5e0c-1251-4fa5-b2e3-af8b6becca02",
-        "opprettetTidspunkt": "2015-02-03T13:57:15.972",
-        "opprettetAv": "srvappserver",
-        "endretKilde": "EDAG",
-        "endretKildereferanse": "eda00000-0000-0000-0000-001883142102",
-        "endretTidspunkt": "2019-06-03T12:04:07.773"
-    },
-    "arbeidsgiver": {
-        "organisasjonsnummer": "981585216",
-        "type": "Organisasjon"
-    },
-    "navArbeidsforholdId": 34977713,
-    "arbeidsforholdId": "1012-20000424-1",
-    "opplysningspliktig": {
-        "organisasjonsnummer": "981566378",
-        "type": "Organisasjon"
-    },
-    "arbeidstaker": {
-        "offentligIdent": "12107548740",
-        "aktoerId": "1000036350643",
-        "type": "Person"
-    },
-    "arbeidsavtaler": [{
-        "antallTimerPrUke": 37.5,
-        "bruksperiode": {
-            "fom": "2019-02-01T11:16:49.299"
-        },
-        "sporingsinformasjon": {
-            "opprettetKilde": "EDAG",
-            "endretAv": "srvappserver",
-            "opprettetKildereferanse": "eda00000-0000-0000-0000-001644633930",
-            "opprettetTidspunkt": "2019-02-01T11:16:49.309",
-            "opprettetAv": "srvappserver",
-            "endretKilde": "EDAG",
-            "endretKildereferanse": "eda00000-0000-0000-0000-001644633930",
-            "endretTidspunkt": "2019-02-01T11:16:49.309"
-        },
-        "arbeidstidsordning": "ikkeSkift",
-        "yrke": "2130123",
-        "sistLoennsendring": "2019-01-01",
-        "gyldighetsperiode": {
-            "fom": "2019-01-01"
-        },
-        "beregnetAntallTimerPrUke": 37.5,
-        "stillingsprosent": 100
-    }],
-    "registrert": "2015-02-03T13:56:45.243",
-    "sistBekreftet": "2019-06-03T11:53:07",
-    "type": "ordinaertArbeidsforhold",
-    "innrapportertEtterAOrdningen": true
-}
-]
+              {
+                "ansettelsesperiode": {
+                  "bruksperiode": {
+                    "fom": "2015-01-06T21:44:04.748",
+                    "tom": "2015-12-06T19:45:04"
+                  },
+                  "periode": {
+                    "fom": "2014-07-01",
+                    "tom": "2015-12-31"
+                  },
+                  "sporingsinformasjon": {
+                    "endretAv": "Z990693",
+                    "endretKilde": "AAREG",
+                    "endretKildereferanse": "referanse-fra-kilde",
+                    "endretTidspunkt": "2018-09-19T12:11:20.79",
+                    "opprettetAv": "srvappserver",
+                    "opprettetKilde": "EDAG",
+                    "opprettetKildereferanse": "22a26849-aeef-4b81-9174-e238c11e1081",
+                    "opprettetTidspunkt": "2018-09-19T12:10:58.059"
+                  },
+                  "varslingskode": "ERKONK"
+                },
+                "antallTimerForTimeloennet": [
+                  {
+                    "antallTimer": 37.5,
+                    "periode": {
+                      "fom": "2014-07-01",
+                      "tom": "2015-12-31"
+                    },
+                    "rapporteringsperiode": "2018-05",
+                    "sporingsinformasjon": {
+                      "endretAv": "Z990693",
+                      "endretKilde": "AAREG",
+                      "endretKildereferanse": "referanse-fra-kilde",
+                      "endretTidspunkt": "2018-09-19T12:11:20.79",
+                      "opprettetAv": "srvappserver",
+                      "opprettetKilde": "EDAG",
+                      "opprettetKildereferanse": "22a26849-aeef-4b81-9174-e238c11e1081",
+                      "opprettetTidspunkt": "2018-09-19T12:10:58.059"
+                    }
+                  }
+                ],
+                "arbeidsavtaler": [
+                  {
+                    "antallTimerPrUke": 37.5,
+                    "arbeidstidsordning": "ikkeSkift",
+                    "beregnetAntallTimerPrUke": 37.5,
+                    "bruksperiode": {
+                      "fom": "2015-01-06T21:44:04.748",
+                      "tom": "2015-12-06T19:45:04"
+                    },
+                    "gyldighetsperiode": {
+                      "fom": "2014-07-01",
+                      "tom": "2015-12-31"
+                    },
+                    "sistLoennsendring": "string",
+                    "sistStillingsendring": "string",
+                    "sporingsinformasjon": {
+                      "endretAv": "Z990693",
+                      "endretKilde": "AAREG",
+                      "endretKildereferanse": "referanse-fra-kilde",
+                      "endretTidspunkt": "2018-09-19T12:11:20.79",
+                      "opprettetAv": "srvappserver",
+                      "opprettetKilde": "EDAG",
+                      "opprettetKildereferanse": "22a26849-aeef-4b81-9174-e238c11e1081",
+                      "opprettetTidspunkt": "2018-09-19T12:10:58.059"
+                    },
+                    "stillingsprosent": 49.5,
+                    "yrke": 2130123
+                  }
+                ],
+                "arbeidsforholdId": "abc-321",
+                "arbeidsgiver": {
+                  "organisasjonsnummer": "123456789",
+                  "type": "DuplikatKey",
+                  "type": "Organisasjon"
+                },
+                "arbeidstaker": {
+                  "type": "Person",
+                  "aktoerId": 1234567890,
+                  "offentligIdent": 31126700000
+                },
+                "innrapportertEtterAOrdningen": true,
+                "navArbeidsforholdId": 123456,
+                "opplysningspliktig": {
+                  "type": "Organisasjon"
+                },
+                "permisjonPermitteringer": [
+                  {
+                    "periode": {
+                      "fom": "2014-07-01",
+                      "tom": "2015-12-31"
+                    },
+                    "permisjonPermitteringId": "123-xyz",
+                    "prosent": 50.5,
+                    "sporingsinformasjon": {
+                      "endretAv": "Z990693",
+                      "endretKilde": "AAREG",
+                      "endretKildereferanse": "referanse-fra-kilde",
+                      "endretTidspunkt": "2018-09-19T12:11:20.79",
+                      "opprettetAv": "srvappserver",
+                      "opprettetKilde": "EDAG",
+                      "opprettetKildereferanse": "22a26849-aeef-4b81-9174-e238c11e1081",
+                      "opprettetTidspunkt": "2018-09-19T12:10:58.059"
+                    },
+                    "type": "permisjonMedForeldrepenger"
+                  }
+                ],
+                "registrert": "2018-09-18T11:12:29",
+                "sistBekreftet": "2018-09-19T12:10:31",
+                "sporingsinformasjon": {
+                  "endretAv": "Z990693",
+                  "endretKilde": "AAREG",
+                  "endretKildereferanse": "referanse-fra-kilde",
+                  "endretTidspunkt": "2018-09-19T12:11:20.79",
+                  "opprettetAv": "srvappserver",
+                  "opprettetKilde": "EDAG",
+                  "opprettetKildereferanse": "22a26849-aeef-4b81-9174-e238c11e1081",
+                  "opprettetTidspunkt": "2018-09-19T12:10:58.059"
+                },
+                "type": "ordinaertArbeidsforhold",
+                "utenlandsopphold": [
+                  {
+                    "landkode": "JPN",
+                    "periode": {
+                      "fom": "2014-07-01",
+                      "tom": "2015-12-31"
+                    },
+                    "rapporteringsperiode": "2017-12",
+                    "sporingsinformasjon": {
+                      "endretAv": "Z990693",
+                      "endretKilde": "AAREG",
+                      "endretKildereferanse": "referanse-fra-kilde",
+                      "endretTidspunkt": "2018-09-19T12:11:20.79",
+                      "opprettetAv": "srvappserver",
+                      "opprettetKilde": "EDAG",
+                      "opprettetKildereferanse": "22a26849-aeef-4b81-9174-e238c11e1081",
+                      "opprettetTidspunkt": "2018-09-19T12:10:58.059"
+                    }
+                  }
+                ]
+              },
+              {
+                "ansettelsesperiode": {
+                  "bruksperiode": {
+                    "fom": "2015-08-13T10:19:33.697"
+                  },
+                  "sporingsinformasjon": {
+                    "opprettetKilde": "EDAG",
+                    "endretAv": "srvappserver",
+                    "opprettetKildereferanse": "9c1857a0-f20a-4d56-8c12-14e32ca2eb62",
+                    "opprettetTidspunkt": "2015-08-13T10:19:33.697",
+                    "opprettetAv": "srvappserver",
+                    "endretKilde": "EDAG",
+                    "endretKildereferanse": "9c1857a0-f20a-4d56-8c12-14e32ca2eb62",
+                    "endretTidspunkt": "2015-08-13T10:19:33.697"
+                  },
+                  "periode": {
+                    "fom": "2000-04-24"
+                  }
+                },
+                "sporingsinformasjon": {
+                  "opprettetKilde": "EDAG",
+                  "endretAv": "srvappserver",
+                  "opprettetKildereferanse": "5eab5e0c-1251-4fa5-b2e3-af8b6becca02",
+                  "opprettetTidspunkt": "2015-02-03T13:57:15.972",
+                  "opprettetAv": "srvappserver",
+                  "endretKilde": "EDAG",
+                  "endretKildereferanse": "eda00000-0000-0000-0000-001883142102",
+                  "endretTidspunkt": "2019-06-03T12:04:07.773"
+                },
+                "arbeidsgiver": {
+                  "organisasjonsnummer": "981585216",
+                  "type": "Organisasjon"
+                },
+                "navArbeidsforholdId": 34977713,
+                "arbeidsforholdId": "1012-20000424-1",
+                "opplysningspliktig": {
+                  "organisasjonsnummer": "981566378",
+                  "type": "Organisasjon"
+                },
+                "arbeidstaker": {
+                  "offentligIdent": "12107548740",
+                  "aktoerId": "1000036350643",
+                  "type": "Person"
+                },
+                "arbeidsavtaler": [
+                  {
+                    "antallTimerPrUke": 37.5,
+                    "bruksperiode": {
+                      "fom": "2019-02-01T11:16:49.299"
+                    },
+                    "sporingsinformasjon": {
+                      "opprettetKilde": "EDAG",
+                      "endretAv": "srvappserver",
+                      "opprettetKildereferanse": "eda00000-0000-0000-0000-001644633930",
+                      "opprettetTidspunkt": "2019-02-01T11:16:49.309",
+                      "opprettetAv": "srvappserver",
+                      "endretKilde": "EDAG",
+                      "endretKildereferanse": "eda00000-0000-0000-0000-001644633930",
+                      "endretTidspunkt": "2019-02-01T11:16:49.309"
+                    },
+                    "arbeidstidsordning": "ikkeSkift",
+                    "yrke": "2130123",
+                    "sistLoennsendring": "2019-01-01",
+                    "gyldighetsperiode": {
+                      "fom": "2019-01-01"
+                    },
+                    "beregnetAntallTimerPrUke": 37.5,
+                    "stillingsprosent": 100
+                  }
+                ],
+                "registrert": "2015-02-03T13:56:45.243",
+                "sistBekreftet": "2019-06-03T11:53:07",
+                "type": "ordinaertArbeidsforhold",
+                "innrapportertEtterAOrdningen": true
+              }
+            ]
         """.trimIndent()
         } else -> {
             return """

--- a/src/test/kotlin/no/nav/k9/wiremocks/EnhetsregResponseTransformer.kt
+++ b/src/test/kotlin/no/nav/k9/wiremocks/EnhetsregResponseTransformer.kt
@@ -30,6 +30,7 @@ class EnhetsregResponseTransformer : ResponseTransformer() {
 }
 
 private fun getResponse(organisasjonsnummer: String) : String {
+    //language=json
     return when (organisasjonsnummer) {
         "981585216" -> """
         {
@@ -145,7 +146,47 @@ private fun getResponse(organisasjonsnummer: String) : String {
             "redigertnavn": "TEIT SELSKAP"
           },
           "opphoersdato": "2017-12-31",
-          "organisasjonsnummer": "123456789"
+          "organisasjonsnummer": "67564534"
+        }
+        """.trimIndent()
+        "11111111" -> """
+        {
+          "adresse": {
+            "adresselinje1": "",
+            "adresselinje2": "",
+            "adresselinje3": "",
+            "bruksperiode": {
+              "fom": "2016-01-06T21:44:04.748",
+              "tom": "2016-12-06T19:45:04"
+            },
+            "gyldighetsperiode": {
+              "fom": "2015-07-01",
+              "tom": "2016-12-31"
+            },
+            "kommunenummer": "0301",
+            "landkode": "NOR",
+            "postnummer": "0557",
+            "poststed": "string"
+          },
+          "enhetstype": "BEDR",
+          "navn": {
+            "bruksperiode": {
+              "fom": "2016-01-06T21:44:04.748",
+              "tom": "2016-12-06T19:45:04"
+            },
+            "gyldighetsperiode": {
+              "fom": "2015-07-01",
+              "tom": "2016-12-31"
+            },
+            "navnelinje1": null,
+            "navnelinje2": null,
+            "navnelinje3": null,
+            "navnelinje4": null,
+            "navnelinje5": null,
+            "redigertnavn": null
+          },
+          "opphoersdato": "2017-12-31",
+          "organisasjonsnummer": "11111111"
         }
         """.trimIndent()
         "1" -> minimalResponse("1", "ENK")

--- a/src/test/kotlin/no/nav/k9/wiremocks/WireMockStubs.kt
+++ b/src/test/kotlin/no/nav/k9/wiremocks/WireMockStubs.kt
@@ -11,7 +11,6 @@ import no.nav.helse.dusseldorf.testsupport.wiremock.WireMockBuilder
 import no.nav.k9.utgaende.rest.NavHeaders
 import no.nav.siftilgangskontroll.core.pdl.utils.PdlOperasjon
 
-private const val aktoerRegisterServerPath = "/aktoer-register-mock"
 private const val arbeidsgiverOgArbeidstakerRegisterServerPath = "/arbeidsgiver-og-arbeidstaker-register-mock"
 private const val enhetsRegisterServerPath = "/enhets-register-mock"
 private const val tpsProxyServerPath = "/tps-proxy-mock"
@@ -141,7 +140,6 @@ internal fun WireMockServer.stubBrregProxyV1(): WireMockServer {
     return this
 }
 
-internal fun WireMockServer.getAktoerRegisterUrl() = baseUrl() + aktoerRegisterServerPath
 internal fun WireMockServer.getArbeidsgiverOgArbeidstakerRegisterUrl() =
     baseUrl() + arbeidsgiverOgArbeidstakerRegisterServerPath
 


### PR DESCRIPTION
- Utvider med info om ansettelsesperiode på oppslag av arbeidsforhold.
 Legger til tester for å teste ønsket funksjonalitet.
- Fjerner gjenstående aktør-register kode etter migrering til PDL.