### PR TITLE
Refaktorerer til HTTP kode 451 ved tilgang nektet.

### DIFF
--- a/src/main/kotlin/no/nav/k9/inngaende/oppslag/OppslagRoute.kt
+++ b/src/main/kotlin/no/nav/k9/inngaende/oppslag/OppslagRoute.kt
@@ -57,7 +57,7 @@ internal fun Route.OppslagRoute(
                         logger = logger,
                         problemDetails = DefaultProblemDetails(
                             title = "tilgangskontroll-feil",
-                            status = 403,
+                            status = 451,
                             instance = URI(call.request.path()),
                             detail = "Policy decision: ${e.policyException.decision} - Reason: ${e.policyException.reason}"
                         )

--- a/src/test/kotlin/no/nav/k9/ApplicationTest.kt
+++ b/src/test/kotlin/no/nav/k9/ApplicationTest.kt
@@ -609,14 +609,14 @@ class ApplicationTest {
     }
 
     @Test
-    fun `gitt oppslag av søker under myndighetsalder, forvent forbidden access (403)`() {
+    fun `gitt oppslag av søker under myndighetsalder, forvent 451 Unavailable For Legal Reasons`() {
         val idToken: String = LoginService.V1_0.generateJwt(PERSON_UNDER_MYNDIGHETS_ALDER)
         with(engine) {
             handleRequest(HttpMethod.Get, "/meg?a=aktør_id") {
                 addHeader(HttpHeaders.Authorization, "Bearer $idToken")
                 addHeader(HttpHeaders.XCorrelationId, "oppslag-ugyldige-attrib")
             }.apply {
-                assertEquals(HttpStatusCode.Forbidden, response.status())
+                assertEquals(451, response.status()!!.value)
                 assertEquals("application/problem+json; charset=UTF-8", response.contentType().toString())
                 //language=json
                 val expectedResponse = """
@@ -625,7 +625,7 @@ class ApplicationTest {
                     "instance": "/meg",
                     "type": "/problem-details/tilgangskontroll-feil",
                     "title": "tilgangskontroll-feil",
-                    "status": 403
+                    "status": 451
                 }
                 """.trimIndent()
                 JSONAssert.assertEquals(expectedResponse, response.content!!, true)


### PR DESCRIPTION
Se [her](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/451) for info om statuskoden.