### PR TITLE
Oppdaterer dusseldorf-ktor, plugins og pakker.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,15 @@
 version: 2
+registries:
+  dusseldorf-ktor:
+    type: maven-repository
+    url: https://maven.pkg.github.com/navikt/dusseldorf-ktor
+    username: x-access-token
+    password: ${{secrets.DEPENDABOT_TOKEN}}
+  sif-tilgangskontroll:
+    type: maven-repository
+    url: https://maven.pkg.github.com/navikt/sif-tilgangskontroll
+    username: x-access-token
+    password: ${{secrets.DEPENDABOT_TOKEN}}
 updates:
   - package-ecosystem: github-actions
     directory: "/"
@@ -10,3 +21,6 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+    registries:
+      - dusseldorf-ktor
+      - sif-tilgangskontroll

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -28,14 +28,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2.4.0
       - name: Cache
-        uses: actions/cache@v2.1.6
+        uses: actions/cache@v2.1.7
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Set up JDK 11
-        uses: actions/setup-java@v2.3.1
+        uses: actions/setup-java@v2.4.0
         with:
           java-version: 11
           distribution: 'zulu'
@@ -51,14 +51,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2.4.0
       - name: Cache
-        uses: actions/cache@v2.1.6
+        uses: actions/cache@v2.1.7
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Set up JDK 11
-        uses: actions/setup-java@v2.3.1
+        uses: actions/setup-java@v2.4.0
         with:
           java-version: 11
           distribution: 'zulu'

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,25 +1,25 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
-val dusseldorfKtorVersion = "3.1.6.4-e07c5ec"
+val dusseldorfKtorVersion = "3.1.6.7-7d29e37"
 val ktorVersion = ext.get("ktorVersion").toString()
 val kotlinVersion = ext.get("kotlinVersion").toString()
-val graphqlKotlinClientVersion = "5.2.0"
+val graphqlKotlinClientVersion = "5.3.1"
 val sifTilgangskontrollVersion = "1-58dcba8"
 
-val mockkVersion = "1.12.0"
+val mockkVersion = "1.12.1"
 val jsonassertVersion = "1.5.0"
 val fuelVersion = "2.3.1"
 
 val mainClass = "no.nav.k9.SelvbetjeningOppslagKt"
 
 plugins {
-    kotlin("jvm") version "1.5.31"
-    id("com.github.johnrengelman.shadow") version "7.1.0"
+    kotlin("jvm") version "1.6.10"
+    id("com.github.johnrengelman.shadow") version "7.1.1"
 }
 
 buildscript {
-    apply("https://raw.githubusercontent.com/navikt/dusseldorf-ktor/e07c5ecf831928eb250c946e753aff2a3b798295/gradle/dusseldorf-ktor.gradle.kts")
+    apply("https://raw.githubusercontent.com/navikt/dusseldorf-ktor/109ae9ba66daf97083e807d314a515fd72d6e69c/gradle/dusseldorf-ktor.gradle.kts")
 }
 
 dependencies {


### PR DESCRIPTION
- Tillater dependabot å lage PR for dusseldorf-ktor og sif-tilgangskontroll oppdateringer.
- closes #90
- closes #89
- closes #88
- closes #85
- closes #83
- closes #82