### PR TITLE
Setter opp endepunkt for å hente identer via systemkall (azure).

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ val ktorVersion = ext.get("ktorVersion").toString()
 val kotlinVersion = ext.get("kotlinVersion").toString()
 val graphqlKotlinClientVersion = "5.3.2"
 val sifTilgangskontrollVersion = "1-c50e1d9"
-val tokenSupportVersion = "2.0.15"
+val tokenSupportVersion = "2.0.17"
 val mockOauth2ServerVersion = "0.4.6"
 
 val mockkVersion = "1.12.3"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ val dusseldorfKtorVersion = "3.1.6.7-05da1a0"
 val ktorVersion = ext.get("ktorVersion").toString()
 val kotlinVersion = ext.get("kotlinVersion").toString()
 val graphqlKotlinClientVersion = "5.3.2"
-val sifTilgangskontrollVersion = "1-2254a85"
+val sifTilgangskontrollVersion = "1-c50e1d9"
 val tokenSupportVersion = "2.0.15"
 val mockOauth2ServerVersion = "0.4.6"
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ val dusseldorfKtorVersion = "3.1.6.7-05da1a0"
 val ktorVersion = ext.get("ktorVersion").toString()
 val kotlinVersion = ext.get("kotlinVersion").toString()
 val graphqlKotlinClientVersion = "5.3.2"
-val sifTilgangskontrollVersion = "1-4881792"
+val sifTilgangskontrollVersion = "1-2254a85"
 
 val mockkVersion = "1.12.3"
 val jsonassertVersion = "1.5.0"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,8 @@ val ktorVersion = ext.get("ktorVersion").toString()
 val kotlinVersion = ext.get("kotlinVersion").toString()
 val graphqlKotlinClientVersion = "5.3.2"
 val sifTilgangskontrollVersion = "1-2254a85"
+val tokenSupportVersion = "2.0.15"
+val mockOauth2ServerVersion = "0.4.6"
 
 val mockkVersion = "1.12.3"
 val jsonassertVersion = "1.5.0"
@@ -33,6 +35,9 @@ dependencies {
     implementation("com.github.kittinunf.fuel:fuel-coroutines:$fuelVersion") {
         exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core")
     }
+
+    implementation ("no.nav.security:token-validation-ktor:$tokenSupportVersion")
+    testImplementation ("no.nav.security:mock-oauth2-server:$mockOauth2ServerVersion")
 
     implementation("no.nav.sif.tilgangskontroll:spesification:$sifTilgangskontrollVersion")
     implementation("no.nav.sif.tilgangskontroll:core:$sifTilgangskontrollVersion") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ val ktorVersion = ext.get("ktorVersion").toString()
 val kotlinVersion = ext.get("kotlinVersion").toString()
 val graphqlKotlinClientVersion = "5.3.2"
 val sifTilgangskontrollVersion = "1-c50e1d9"
-val tokenSupportVersion = "2.0.17"
+val tokenSupportVersion = "2.0.19"
 val mockOauth2ServerVersion = "0.4.6"
 
 val mockkVersion = "1.12.3"

--- a/nais/dev-fss.json
+++ b/nais/dev-fss.json
@@ -11,7 +11,6 @@
   ],
   "azureTenant": "trygdeetaten.no",
   "env": {
-    "LOGIN_SERVICE_V1_DISCOVERY_ENDPOINT": "https://login.microsoftonline.com/NAVtestB2C.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=B2C_1A_idporten_ver1",
     "ARBEIDSGIVER_OG_ARBEIDSTAKER_V1_URL": "https://aareg-services-q1.dev.intern.nav.no/api/v1",
     "AAREG_TOKENX_AUDIENCE": "dev-fss:arbeidsforhold:aareg-services-nais",
     "ENHET_V1_URL": "https://ereg-services-q1.dev.intern.nav.no/api/v1/",

--- a/nais/prod-fss.json
+++ b/nais/prod-fss.json
@@ -11,7 +11,6 @@
   ],
   "azureTenant": "nav.no",
   "env": {
-    "LOGIN_SERVICE_V1_DISCOVERY_ENDPOINT": "https://login.microsoftonline.com/navnob2c.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=B2C_1A_idporten",
     "ARBEIDSGIVER_OG_ARBEIDSTAKER_V1_URL": "https://aareg-services.intern.nav.no/api/v1",
     "AAREG_TOKENX_AUDIENCE": "prod-fss:arbeidsforhold:aareg-services-nais",
     "ENHET_V1_URL": "https://ereg-services.intern.nav.no/api/v1/",

--- a/src/main/kotlin/no/nav/k9/SelvbetjeningOppslag.kt
+++ b/src/main/kotlin/no/nav/k9/SelvbetjeningOppslag.kt
@@ -33,6 +33,7 @@ import no.nav.k9.inngaende.oppslag.SystemOppslagService
 import no.nav.k9.utgaende.auth.AccessTokenClientResolver
 import no.nav.k9.utgaende.gateway.*
 import no.nav.k9.utgaende.rest.*
+import no.nav.security.token.support.core.configuration.ProxyAwareResourceRetriever
 import no.nav.security.token.support.ktor.RequiredClaims
 import no.nav.security.token.support.ktor.asIssuerProps
 import no.nav.security.token.support.ktor.tokenValidationSupport
@@ -65,7 +66,8 @@ fun Application.SelvbetjeningOppslag() {
                     requiredClaims = RequiredClaims(
                         issuer = issuer,
                         claimMap = arrayOf("acr=Level4")
-                    )
+                    ),
+                    resourceRetriever = ProxyAwareResourceRetriever()
                 )
             }
 

--- a/src/main/kotlin/no/nav/k9/SelvbetjeningOppslag.kt
+++ b/src/main/kotlin/no/nav/k9/SelvbetjeningOppslag.kt
@@ -77,7 +77,7 @@ fun Application.SelvbetjeningOppslag() {
                     config = config,
                     requiredClaims = RequiredClaims(
                         issuer = issuer,
-                        claimMap = arrayOf("role=access_as_application")
+                        claimMap = arrayOf("roles=access_as_application")
                     )
                 )
             }

--- a/src/main/kotlin/no/nav/k9/SelvbetjeningOppslag.kt
+++ b/src/main/kotlin/no/nav/k9/SelvbetjeningOppslag.kt
@@ -33,7 +33,6 @@ import no.nav.k9.inngaende.oppslag.SystemOppslagService
 import no.nav.k9.utgaende.auth.AccessTokenClientResolver
 import no.nav.k9.utgaende.gateway.*
 import no.nav.k9.utgaende.rest.*
-import no.nav.security.token.support.core.configuration.ProxyAwareResourceRetriever
 import no.nav.security.token.support.ktor.RequiredClaims
 import no.nav.security.token.support.ktor.asIssuerProps
 import no.nav.security.token.support.ktor.tokenValidationSupport
@@ -66,8 +65,7 @@ fun Application.SelvbetjeningOppslag() {
                     requiredClaims = RequiredClaims(
                         issuer = issuer,
                         claimMap = arrayOf("acr=Level4")
-                    ),
-                    resourceRetriever = ProxyAwareResourceRetriever()
+                    )
                 )
             }
 

--- a/src/main/kotlin/no/nav/k9/inngaende/oppslag/MegOppslag.kt
+++ b/src/main/kotlin/no/nav/k9/inngaende/oppslag/MegOppslag.kt
@@ -42,7 +42,7 @@ internal class MegOppslag(
 
 fun Person.barnIdenter(): List<Ident> = forelderBarnRelasjon
     .filter { it.relatertPersonsRolle == ForelderBarnRelasjonRolle.BARN }
-    .map { Ident(it.relatertPersonsIdent) }
+    .map { Ident(it.relatertPersonsIdent!!) }
 
 data class PdlPerson(
     internal val fornavn: String,

--- a/src/main/kotlin/no/nav/k9/inngaende/oppslag/SystemOppslagRoute.kt
+++ b/src/main/kotlin/no/nav/k9/inngaende/oppslag/SystemOppslagRoute.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.withContext
 import no.nav.helse.dusseldorf.ktor.auth.idToken
 import no.nav.k9.inngaende.RequestContextService
 import no.nav.k9.inngaende.correlationId
+import no.nav.k9.objectMapper
 import no.nav.siftilgangskontroll.pdl.generated.enums.IdentGruppe
 
 internal fun Route.SystemOppslagRoute(
@@ -16,7 +17,7 @@ internal fun Route.SystemOppslagRoute(
 
     post("/system/hent-identer") {
         val idToken = call.idToken()
-        val hentIdenterForespørsel = call.receive<HentIdenterForespørsel>()
+        val hentIdenterForespørsel = objectMapper().readValue(call.receive<String>(), HentIdenterForespørsel::class.java)
 
         withContext(requestContextService.getCoroutineContext(
             context = coroutineContext,

--- a/src/main/kotlin/no/nav/k9/inngaende/oppslag/SystemOppslagRoute.kt
+++ b/src/main/kotlin/no/nav/k9/inngaende/oppslag/SystemOppslagRoute.kt
@@ -1,0 +1,37 @@
+package no.nav.k9.inngaende.oppslag
+
+import io.ktor.application.*
+import io.ktor.request.*
+import io.ktor.routing.*
+import kotlinx.coroutines.withContext
+import no.nav.helse.dusseldorf.ktor.auth.idToken
+import no.nav.k9.inngaende.RequestContextService
+import no.nav.k9.inngaende.correlationId
+import no.nav.siftilgangskontroll.pdl.generated.enums.IdentGruppe
+
+internal fun Route.SystemOppslagRoute(
+    requestContextService: RequestContextService,
+    systemOppslagService: SystemOppslagService,
+) {
+
+    post("/system/hent-identer") {
+        val idToken = call.idToken()
+        val hentIdenterForespørsel = call.receive<HentIdenterForespørsel>()
+
+        withContext(requestContextService.getCoroutineContext(
+            context = coroutineContext,
+            correlationId = call.correlationId(),
+            idToken = idToken
+        )) {
+            systemOppslagService.hentIdenter(
+                identer = hentIdenterForespørsel.identer,
+                identGrupper = hentIdenterForespørsel.identGrupper
+            )
+        }
+    }
+}
+
+internal data class HentIdenterForespørsel(
+    val identer: List<String>,
+    val identGrupper: List<IdentGruppe>
+)

--- a/src/main/kotlin/no/nav/k9/inngaende/oppslag/SystemOppslagRoute.kt
+++ b/src/main/kotlin/no/nav/k9/inngaende/oppslag/SystemOppslagRoute.kt
@@ -2,6 +2,7 @@ package no.nav.k9.inngaende.oppslag
 
 import io.ktor.application.*
 import io.ktor.request.*
+import io.ktor.response.*
 import io.ktor.routing.*
 import kotlinx.coroutines.withContext
 import no.nav.helse.dusseldorf.ktor.auth.idToken
@@ -24,10 +25,12 @@ internal fun Route.SystemOppslagRoute(
             correlationId = call.correlationId(),
             idToken = idToken
         )) {
-            systemOppslagService.hentIdenter(
+            val hentIdenterBolkResults = systemOppslagService.hentIdenter(
                 identer = hentIdenterForespørsel.identer,
                 identGrupper = hentIdenterForespørsel.identGrupper
             )
+
+            call.respond(hentIdenterBolkResults)
         }
     }
 }

--- a/src/main/kotlin/no/nav/k9/inngaende/oppslag/SystemOppslagService.kt
+++ b/src/main/kotlin/no/nav/k9/inngaende/oppslag/SystemOppslagService.kt
@@ -1,0 +1,14 @@
+package no.nav.k9.inngaende.oppslag
+
+import no.nav.k9.utgaende.gateway.PDLProxyGateway
+import no.nav.siftilgangskontroll.pdl.generated.enums.IdentGruppe
+import no.nav.siftilgangskontroll.pdl.generated.hentidenterbolk.HentIdenterBolkResult
+
+class SystemOppslagService(
+    private val pdlProxyGateway: PDLProxyGateway
+) {
+
+    suspend fun hentIdenter(identer: List<String>, identGrupper: List<IdentGruppe>): List<HentIdenterBolkResult> {
+        return pdlProxyGateway.hentIdenter(identer, identGrupper)
+    }
+}

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -17,10 +17,6 @@ no.nav.security.jwt {
          accepted_audience = ${?TOKEN_X_CLIENT_ID}
       },
       {
-        issuer_name = login-service-v1
-        discoveryurl = ${?LOGIN_SERVICE_V1_DISCOVERY_ENDPOINT}
-      },
-      {
         issuer_name = login-service-v2
         discoveryurl = ${?LOGINSERVICE_IDPORTEN_DISCOVERY_URL}
         accepted_audience = ${?LOGINSERVICE_IDPORTEN_AUDIENCE}

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -9,6 +9,30 @@ ktor {
     }
 }
 
+no.nav.security.jwt {
+  issuers = [
+      {
+         issuer_name = tokendings
+         discoveryurl = ${?TOKEN_X_WELL_KNOWN_URL}
+         accepted_audience = ${?TOKEN_X_CLIENT_ID}
+      },
+      {
+        issuer_name = login-service-v1
+        discoveryurl = ${?LOGIN_SERVICE_V1_DISCOVERY_ENDPOINT}
+      },
+      {
+        issuer_name = login-service-v2
+        discoveryurl = ${?LOGINSERVICE_IDPORTEN_DISCOVERY_URL}
+        accepted_audience = ${?LOGINSERVICE_IDPORTEN_AUDIENCE}
+      },
+      {
+        issuer_name = azure
+        discoveryurl = ${?AZURE_APP_WELL_KNOWN_URL}
+        accepted_audience = ${?AZURE_APP_CLIENT_ID}
+      }
+  ]
+}
+
 nav {
     register_urls {
         arbeidsgiver_og_arbeidstaker_v1 = ""
@@ -37,34 +61,6 @@ nav {
               discovery_endpoint = ${?AZURE_APP_WELL_KNOWN_URL}
             }
         ]
-        issuers = [
-        {
-            alias = "login-service-v1"
-            discovery_endpoint = ""
-            discovery_endpoint = ${?LOGIN_SERVICE_V1_DISCOVERY_ENDPOINT}
-        },
-        {
-            alias = "login-service-v2"
-            discovery_endpoint = ""
-            discovery_endpoint = ${?LOGINSERVICE_IDPORTEN_DISCOVERY_URL}
-            audience = ""
-            audience = ${?LOGINSERVICE_IDPORTEN_AUDIENCE}
-        },{
-            alias = "tokenx"
-            discovery_endpoint = ""
-            discovery_endpoint = ${?TOKEN_X_WELL_KNOWN_URL}
-            audience = ""
-            audience = ${?TOKEN_X_CLIENT_ID}
-        },{
-            alias = "azure"
-            discovery_endpoint = ""
-            discovery_endpoint = ${?AZURE_APP_WELL_KNOWN_URL}
-            audience = ""
-            audience = ${?AZURE_APP_CLIENT_ID}
-            azure {
-                required_roles = "access_as_application"
-            }
-        }],
         client_id = ""
         client_id = ${?CLIENT_ID}
         client_secret = ""

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -15,7 +15,6 @@ no.nav.security.jwt {
          issuer_name = tokendings
          discoveryurl = ${?TOKEN_X_WELL_KNOWN_URL}
          accepted_audience = ${?TOKEN_X_CLIENT_ID}
-         proxyurl = ${?NO_PROXY}
       },
       {
         issuer_name = login-service-v2

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -55,6 +55,15 @@ nav {
             discovery_endpoint = ${?TOKEN_X_WELL_KNOWN_URL}
             audience = ""
             audience = ${?TOKEN_X_CLIENT_ID}
+        },{
+            alias = "azure"
+            discovery_endpoint = ""
+            discovery_endpoint = ${?AZURE_APP_WELL_KNOWN_URL}
+            audience = ""
+            audience = ${?AZURE_APP_CLIENT_ID}
+            azure {
+                required_roles = "access_as_application"
+            }
         }],
         client_id = ""
         client_id = ${?CLIENT_ID}

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -15,6 +15,7 @@ no.nav.security.jwt {
          issuer_name = tokendings
          discoveryurl = ${?TOKEN_X_WELL_KNOWN_URL}
          accepted_audience = ${?TOKEN_X_CLIENT_ID}
+         proxyurl = ${?NO_PROXY}
       },
       {
         issuer_name = login-service-v2

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -4,7 +4,7 @@
         <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
     </appender>
 
-    <logger name="no.nav" level="INFO"/>
+    <logger name="no.nav" level="DEBUG"/>
     <logger name="io.ktor.auth.jwt" level="TRACE" />
 
     <root level="INFO">

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -4,7 +4,7 @@
         <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
     </appender>
 
-    <logger name="no.nav" level="DEBUG"/>
+    <logger name="no.nav" level="INFO"/>
     <logger name="io.ktor.auth.jwt" level="TRACE" />
 
     <root level="INFO">

--- a/src/test/kotlin/no/nav/k9/ApplicationTest.kt
+++ b/src/test/kotlin/no/nav/k9/ApplicationTest.kt
@@ -126,7 +126,7 @@ class ApplicationTest {
 
     @Test
     fun `test megOppslag aktoerId`() {
-        val idToken: String = mockOAuth2Server.hentToken(issuerId = "login-service-v1", subject = PERSON_1_MED_BARN)
+        val idToken: String = mockOAuth2Server.hentToken(issuerId = "login-service-v2", subject = PERSON_1_MED_BARN)
         with(engine) {
             handleRequest(HttpMethod.Get, "/meg?a=aktør_id") {
                 addHeader(HttpHeaders.Authorization, "Bearer $idToken")
@@ -163,7 +163,7 @@ class ApplicationTest {
 
     @Test
     fun `test megOppslag aktoerId med tokenx token med subjectToken fra IDPorten`() {
-        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v1", subject = PERSON_1_MED_BARN)
+        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v2", subject = PERSON_1_MED_BARN)
 
         with(engine) {
             handleRequest(HttpMethod.Get, "/meg?a=aktør_id") {
@@ -247,7 +247,7 @@ class ApplicationTest {
 
     @Test
     fun `test megOppslag aktør_id og fornavn`() {
-        val idToken: String = mockOAuth2Server.hentToken(issuerId = "login-service-v1", subject = PERSON_2_MED_BARN)
+        val idToken: String = mockOAuth2Server.hentToken(issuerId = "login-service-v2", subject = PERSON_2_MED_BARN)
         with(engine) {
             handleRequest(HttpMethod.Get, "/meg?a=aktør_id&a=fornavn") {
                 addHeader(HttpHeaders.Authorization, "Bearer $idToken")
@@ -266,7 +266,7 @@ class ApplicationTest {
 
     @Test
     fun `test megOppslag aktør_id og navn og fødselsdato`() {
-        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v1", subject = PERSON_2_MED_BARN)
+        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v2", subject = PERSON_2_MED_BARN)
         with(engine) {
             handleRequest(HttpMethod.Get, "/meg?a=aktør_id&a=fornavn&a=mellomnavn&a=etternavn&a=fødselsdato") {
                 addHeader(HttpHeaders.Authorization, "Bearer $idToken")
@@ -290,7 +290,7 @@ class ApplicationTest {
 
     @Test
     fun `test megOppslag navn har ikke mellomnavn`() {
-        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v1", subject = "01010067894")
+        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v2", subject = "01010067894")
         with(engine) {
             handleRequest(HttpMethod.Get, "/meg?a=fornavn&a=mellomnavn&a=etternavn") {
                 addHeader(HttpHeaders.Authorization, "Bearer $idToken")
@@ -312,7 +312,7 @@ class ApplicationTest {
 
     @Test
     fun `gitt oppslag av død person, forvent feil`() {
-        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v1", subject = DØD_PERSON)
+        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v2", subject = DØD_PERSON)
         with(engine) {
             handleRequest(HttpMethod.Get, "/meg?a=fornavn&a=mellomnavn&a=etternavn") {
                 addHeader(HttpHeaders.Authorization, "Bearer $idToken")
@@ -325,7 +325,7 @@ class ApplicationTest {
 
     @Test
     fun `gitt oppslag av person under myndighetsalder (18), forvent feil`() {
-        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v1", subject = PERSON_UNDER_MYNDIGHETS_ALDER)
+        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v2", subject = PERSON_UNDER_MYNDIGHETS_ALDER)
         with(engine) {
             handleRequest(HttpMethod.Get, "/meg?a=fornavn&a=mellomnavn&a=etternavn") {
                 addHeader(HttpHeaders.Authorization, "Bearer $idToken")
@@ -338,7 +338,7 @@ class ApplicationTest {
 
     @Test
     fun `test barnOppslag aktoerId`() {
-        val idToken: String = mockOAuth2Server.hentToken(issuerId = "login-service-v1", subject = PERSON_2_MED_BARN)
+        val idToken: String = mockOAuth2Server.hentToken(issuerId = "login-service-v2", subject = PERSON_2_MED_BARN)
         with(engine) {
             handleRequest(HttpMethod.Get, "/meg?a=barn[].aktør_id") {
                 addHeader(HttpHeaders.Authorization, "Bearer $idToken")
@@ -364,7 +364,7 @@ class ApplicationTest {
 
     @Test
     fun `test barnOppslag navn og fødselsdato`() {
-        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v1", subject = PERSON_2_MED_BARN)
+        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v2", subject = PERSON_2_MED_BARN)
         with(engine) {
             handleRequest(
                 HttpMethod.Get,
@@ -396,7 +396,7 @@ class ApplicationTest {
 
     @Test
     fun `test barnOppslag navn har ikke mellomnavn`() {
-        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v1", subject = PERSON_1_MED_BARN)
+        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v2", subject = PERSON_1_MED_BARN)
         with(engine) {
             handleRequest(HttpMethod.Get, "/meg?a=barn[].fornavn&a=barn[].mellomnavn&a=barn[].etternavn") {
                 addHeader(HttpHeaders.Authorization, "Bearer $idToken")
@@ -422,7 +422,7 @@ class ApplicationTest {
     @Test
     fun `gitt barn med strengt fortrolig adresse, forvent tom liste`() {
         val idToken: String =
-            mockOAuth2Server.hentToken(issuerId = "login-service-v1", subject = PERSON_3_MED_SKJERMET_BARN)
+            mockOAuth2Server.hentToken(issuerId = "login-service-v2", subject = PERSON_3_MED_SKJERMET_BARN)
         with(engine) {
             handleRequest(HttpMethod.Get, "/meg?a=barn[].fornavn&a=barn[].mellomnavn&a=barn[].etternavn") {
                 addHeader(HttpHeaders.Authorization, "Bearer $idToken")
@@ -442,7 +442,7 @@ class ApplicationTest {
 
     @Test
     fun `gitt død barn, forvent tom liste`() {
-        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v1", subject = PERSON_4_MED_DØD_BARN)
+        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v2", subject = PERSON_4_MED_DØD_BARN)
         with(engine) {
             handleRequest(HttpMethod.Get, "/meg?a=barn[].fornavn&a=barn[].mellomnavn&a=barn[].etternavn") {
                 addHeader(HttpHeaders.Authorization, "Bearer $idToken")
@@ -462,7 +462,7 @@ class ApplicationTest {
 
     @Test
     fun `test barnOppslag ingenBarn`() {
-        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v1", subject = PERSON_UTEN_BARN)
+        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v2", subject = PERSON_UTEN_BARN)
         with(engine) {
             handleRequest(HttpMethod.Get, "/meg?a=barn[].fornavn&a=barn[].mellomnavn&a=barn[].etternavn") {
                 addHeader(HttpHeaders.Authorization, "Bearer $idToken")
@@ -482,7 +482,7 @@ class ApplicationTest {
 
     @Test
     fun `test arbeidsgiverOppslag orgnr`() {
-        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v1", subject = PERSON_1_MED_BARN)
+        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v2", subject = PERSON_1_MED_BARN)
         with(engine) {
             handleRequest(HttpMethod.Get, "/meg?a=arbeidsgivere[].organisasjoner[].organisasjonsnummer") {
                 addHeader(HttpHeaders.Authorization, "Bearer $idToken")
@@ -511,7 +511,7 @@ class ApplicationTest {
 
     @Test
     fun `test arbeidsgiverOppslag orgnr og navn`() {
-        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v1", subject = PERSON_1_MED_BARN)
+        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v2", subject = PERSON_1_MED_BARN)
         with(engine) {
             handleRequest(
                 HttpMethod.Get,
@@ -545,7 +545,7 @@ class ApplicationTest {
 
     @Test
     fun `Forvent organiasjon uten navn, gitt at navn ikke er funnet`() {
-        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v1", subject = PERSON_1_MED_BARN)
+        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v2", subject = PERSON_1_MED_BARN)
         with(engine) {
             handleRequest(
                 HttpMethod.Get,
@@ -575,7 +575,7 @@ class ApplicationTest {
 
     @Test
     fun `Forvent 1 organisasjon med navn, gitt organisasjonsnummer`() {
-        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v1", subject = PERSON_1_MED_BARN)
+        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v2", subject = PERSON_1_MED_BARN)
         with(engine) {
             handleRequest(
                 HttpMethod.Get,
@@ -606,7 +606,7 @@ class ApplicationTest {
 
     @Test
     fun `Forvent 2 organisasjoner med navn, gitt organisasjonsnummer`() {
-        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v1", subject = PERSON_1_MED_BARN)
+        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v2", subject = PERSON_1_MED_BARN)
         with(engine) {
             handleRequest(
                 HttpMethod.Get,
@@ -641,7 +641,7 @@ class ApplicationTest {
 
     @Test
     fun `test arbeidsgiverOppslag orgnr, navn, fom og tom`() {
-        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v1", subject = PERSON_1_MED_BARN)
+        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v2", subject = PERSON_1_MED_BARN)
         with(engine) {
             handleRequest(
                 HttpMethod.Get,
@@ -679,7 +679,7 @@ class ApplicationTest {
 
     @Test
     fun `test arbeidsgiverOppslag med ingen arbeidsgivere`() {
-        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v1", subject = PERSON_UTEN_ARBEIDSGIVER)
+        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v2", subject = PERSON_UTEN_ARBEIDSGIVER)
         with(engine) {
             handleRequest(
                 HttpMethod.Get,
@@ -706,7 +706,7 @@ class ApplicationTest {
 
     @Test
     fun `tester oppslag av private arbeidsgivere`() {
-        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v1", subject = PERSON_1_MED_BARN)
+        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v2", subject = PERSON_1_MED_BARN)
         with(engine) {
             handleRequest(
                 HttpMethod.Get,
@@ -737,7 +737,7 @@ class ApplicationTest {
 
     @Test
     fun `Forventer å kun få unike arbeidsgivere selvom man har flere arbeidsforhold hos en arbeidsgiver`() {
-        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v1", subject = PERSON_MED_FLERE_ARBEIDSFORHOLD_PER_ARBEIDSGIVER)
+        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v2", subject = PERSON_MED_FLERE_ARBEIDSFORHOLD_PER_ARBEIDSGIVER)
         with(engine) {
             handleRequest(
                 HttpMethod.Get,
@@ -776,7 +776,7 @@ class ApplicationTest {
 
     @Test
     fun `Teste oppslag av frilans oppdrag`() {
-        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v1", subject = PERSON_MED_FRILANS_OPPDRAG)
+        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v2", subject = PERSON_MED_FRILANS_OPPDRAG)
         with(engine) {
             handleRequest(
                 HttpMethod.Get,
@@ -815,7 +815,7 @@ class ApplicationTest {
 
     @Test
     fun `test oppslag alle attributter`() {
-        val idToken: String = mockOAuth2Server.hentToken(issuerId = "login-service-v1", subject = PERSON_1_MED_BARN)
+        val idToken: String = mockOAuth2Server.hentToken(issuerId = "login-service-v2", subject = PERSON_1_MED_BARN)
         with(engine) {
             handleRequest(
                 HttpMethod.Get, "/meg?fom=2019-09-09&tom=2019-10-10" +
@@ -872,7 +872,7 @@ class ApplicationTest {
 
     @Test
     fun `test oppslag ingen attributter skal returnere tom JSON`() {
-        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v1", subject = PERSON_1_MED_BARN)
+        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v2", subject = PERSON_1_MED_BARN)
         with(engine) {
             handleRequest(HttpMethod.Get, "/meg") {
                 addHeader(HttpHeaders.Authorization, "Bearer $idToken")
@@ -890,7 +890,7 @@ class ApplicationTest {
 
     @Test
     fun `test oppslag bare ugyldig attributt - bad request`() {
-        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v1", subject = PERSON_1_MED_BARN)
+        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v2", subject = PERSON_1_MED_BARN)
         with(engine) {
             handleRequest(HttpMethod.Get, "/meg?a=ugyldigAttrib") {
                 addHeader(HttpHeaders.Authorization, "Bearer $idToken")
@@ -917,7 +917,7 @@ class ApplicationTest {
 
     @Test
     fun `test oppslag ugyldige attributt - bad request`() {
-        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v1", subject = PERSON_1_MED_BARN)
+        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v2", subject = PERSON_1_MED_BARN)
         with(engine) {
             handleRequest(HttpMethod.Get, "/meg?a=aktør_id&a=ugyldigattrib&a=fornavn&a=annetugyldigattrib") {
                 addHeader(HttpHeaders.Authorization, "Bearer $idToken")
@@ -945,7 +945,7 @@ class ApplicationTest {
 
     @Test
     fun `gitt oppslag av søker under myndighetsalder, forvent 451 Unavailable For Legal Reasons`() {
-        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v1", subject = PERSON_UNDER_MYNDIGHETS_ALDER)
+        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v2", subject = PERSON_UNDER_MYNDIGHETS_ALDER)
         with(engine) {
             handleRequest(HttpMethod.Get, "/meg?a=aktør_id") {
                 addHeader(HttpHeaders.Authorization, "Bearer $idToken")
@@ -970,7 +970,7 @@ class ApplicationTest {
 
     @Test
     fun `test arbeidsgiverOppslag feil format fom`() {
-        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v1", subject = PERSON_1_MED_BARN)
+        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v2", subject = PERSON_1_MED_BARN)
         with(engine) {
             handleRequest(
                 HttpMethod.Get,
@@ -1000,7 +1000,7 @@ class ApplicationTest {
 
     @Test
     fun `test arbeidsgiverOppslag feil format tom`() {
-        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v1", subject = PERSON_1_MED_BARN)
+        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v2", subject = PERSON_1_MED_BARN)
         with(engine) {
             handleRequest(
                 HttpMethod.Get,
@@ -1030,7 +1030,7 @@ class ApplicationTest {
 
     @Test
     fun `Hente personlige foretak for en person som har det`() {
-        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v1", subject = PERSON_MED_FORETAK)
+        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v2", subject = PERSON_MED_FORETAK)
         with(engine) {
             handleRequest(
                 HttpMethod.Get,
@@ -1066,7 +1066,7 @@ class ApplicationTest {
 
     @Test
     fun `Hente personlige foretak for en person som ikke har det`() {
-        val idToken: String = mockOAuth2Server.hentToken(issuerId = "login-service-v1", subject = PERSON_UTEN_FORETAK)
+        val idToken: String = mockOAuth2Server.hentToken(issuerId = "login-service-v2", subject = PERSON_UTEN_FORETAK)
         with(engine) {
             handleRequest(
                 HttpMethod.Get,
@@ -1089,7 +1089,7 @@ class ApplicationTest {
 
     @Test
     fun `Hente personlige foretak for en person som har fler roller i samme foretak`() {
-        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v1", subject = PERSON_MED_FLERE_ROLLER_I_FORETAK)
+        val idToken: String =  mockOAuth2Server.hentToken(issuerId = "login-service-v2", subject = PERSON_MED_FLERE_ROLLER_I_FORETAK)
         with(engine) {
             handleRequest(
                 HttpMethod.Get,

--- a/src/test/kotlin/no/nav/k9/ApplicationTest.kt
+++ b/src/test/kotlin/no/nav/k9/ApplicationTest.kt
@@ -206,7 +206,7 @@ class ApplicationTest {
             issuerId = "azure",
             subject = UUID.randomUUID().toString(),
             audience = "dev-fss:dusseldorf:k9-selvbetjening-oppslag",
-            claims = mapOf("role" to "access_as_application")
+            claims = mapOf("roles" to "access_as_application")
         ).serialize()
 
         with(engine) {

--- a/src/test/kotlin/no/nav/k9/ApplicationTest.kt
+++ b/src/test/kotlin/no/nav/k9/ApplicationTest.kt
@@ -57,6 +57,7 @@ class ApplicationTest {
             .stubPDLRequest(PdlOperasjon.HENT_PERSON)
             .stubPDLRequest(PdlOperasjon.HENT_PERSON_BOLK)
             .stubPDLRequest(PdlOperasjon.HENT_IDENTER)
+            .stubPDLRequest(PdlOperasjon.HENT_IDENTER_BOLK)
             .stubArbeidsgiverOgArbeidstakerRegister()
             .stubEnhetsRegister()
             .stubBrregProxyV1()
@@ -79,18 +80,6 @@ class ApplicationTest {
         val engine = TestApplicationEngine(createTestEnvironment {
             config = getConfig()
         })
-
-        private val assertionJwt = Tokendings.generateAssertionJwt(mapOf(
-            "client_id" to "dev-fss:dusseldorf:k9-selvbetjening-oppslag",
-            "iss" to "dev-fss:dusseldorf:k9-selvbetjening-oppslag",
-            "aud" to Tokendings.getAudience(),
-            "sub" to "dev-fss:dusseldorf:k9-selvbetjening-oppslag",
-            "iat" to LocalDateTime.now().toDate(),
-            "nbf" to LocalDateTime.now().toDate(),
-            "exp" to LocalDateTime.now().plusSeconds(200).toDate(),
-            "jti" to UUID.randomUUID().toString(),
-        ))
-
 
         @BeforeAll
         @JvmStatic
@@ -230,11 +219,28 @@ class ApplicationTest {
                 setBody("""
                     {
                         "identer": ["$PERSON_1_MED_BARN"],
-                        "identGrupper": ["${IdentGruppe.AKTORID}"]
+                        "identGrupper": ["${IdentGruppe.FOLKEREGISTERIDENT}"]
                     }
                 """.trimIndent())
             }.apply {
                 assertEquals(HttpStatusCode.OK, response.status())
+                //language=json
+                val expectedResponse = """
+                    {
+                      "data": {
+                        "hentIdenterBolk": [
+                          {
+                            "identer": [
+                              {
+                                "ident": "$PERSON_1_MED_BARN",
+                                "gruppe": "${IdentGruppe.FOLKEREGISTERIDENT}"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                """.trimIndent()
             }
         }
     }

--- a/src/test/kotlin/no/nav/k9/ApplicationWithMocks.kt
+++ b/src/test/kotlin/no/nav/k9/ApplicationWithMocks.kt
@@ -7,6 +7,7 @@ import no.nav.k9.wiremocks.*
 import no.nav.k9.wiremocks.k9SelvbetjeningOppslagConfig
 import no.nav.k9.wiremocks.stubArbeidsgiverOgArbeidstakerRegister
 import no.nav.k9.wiremocks.stubEnhetsRegister
+import no.nav.security.mock.oauth2.MockOAuth2Server
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -17,6 +18,7 @@ class ApplicationWithMocks {
 
         @JvmStatic
         fun main(args: Array<String>) {
+            val mockOAuth2Server = MockOAuth2Server().apply { start() }
 
             val wireMockServer = WireMockBuilder()
                 .withPort(8081)
@@ -28,7 +30,10 @@ class ApplicationWithMocks {
                 .stubEnhetsRegister()
                 .stubBrregProxyV1()
 
-            val testArgs = TestConfiguration.asMap(wireMockServer = wireMockServer).asArguments()
+            val testArgs = TestConfiguration.asMap(
+                wireMockServer = wireMockServer,
+                mockOAuth2Server = mockOAuth2Server
+            ).asArguments()
 
             Runtime.getRuntime().addShutdownHook(object : Thread() {
                 override fun run() {

--- a/src/test/kotlin/no/nav/k9/FødselsnummerOversikt.kt
+++ b/src/test/kotlin/no/nav/k9/FødselsnummerOversikt.kt
@@ -14,7 +14,6 @@ object PersonFødselsnummer {
     const val PERSON_UTEN_ARBEIDSGIVER = "02029212345"
     const val PERSON_MED_FLERE_ARBEIDSFORHOLD_PER_ARBEIDSGIVER = "04047316486"
     const val PERSON_MED_FRILANS_OPPDRAG = "14047316486"
-
 }
 
 object BarnFødselsnummer {

--- a/src/test/kotlin/no/nav/k9/TestConfiguration.kt
+++ b/src/test/kotlin/no/nav/k9/TestConfiguration.kt
@@ -5,12 +5,14 @@ import com.github.tomakehurst.wiremock.WireMockServer
 import no.nav.helse.dusseldorf.testsupport.jws.ClientCredentials
 import no.nav.helse.dusseldorf.testsupport.wiremock.*
 import no.nav.k9.wiremocks.*
+import no.nav.security.mock.oauth2.MockOAuth2Server
 import org.json.JSONObject
 
 object TestConfiguration {
 
     fun asMap(
         wireMockServer: WireMockServer? = null,
+        mockOAuth2Server: MockOAuth2Server? = null,
         port : Int = 8080,
         arbeidsgiverOgArbeidstakerRegisterBaseUrl : String? = wireMockServer?.getArbeidsgiverOgArbeidstakerRegisterUrl(),
         enhetsRegisterBaseUrl : String? = wireMockServer?.getEnhetsregisterUrl(),
@@ -36,24 +38,23 @@ object TestConfiguration {
             Pair("nav.auth.pdl_api_azure_audience", "dev-fss.pdl.pdl-api/.default"),
             Pair("nav.auth.aareg_tokenx_audience", "dev-fss.arbeidsforhold.aareg-services-nais"),
 
-            Pair("nav.auth.issuers.0.alias", "login-service-v1"),
-            Pair("nav.auth.issuers.0.discovery_endpoint", wireMockServer!!.getLoginServiceV1WellKnownUrl()),
-            Pair("nav.auth.issuers.0.audience", "dev-fss:dusseldorf:k9-selvbetjening-oppslag"),
+            Pair("no.nav.security.jwt.issuers.0.issuer_name", "tokendings"),
+            Pair("no.nav.security.jwt.issuers.0.discoveryurl", "${mockOAuth2Server!!.wellKnownUrl("tokendings")}"),
+            Pair("no.nav.security.jwt.issuers.0.accepted_audience", "dev-fss:dusseldorf:k9-selvbetjening-oppslag"),
 
-            Pair("nav.auth.issuers.1.alias", "tokenx"),
-            Pair("nav.auth.issuers.1.discovery_endpoint", wireMockServer.getTokendingsWellKnownUrl()),
-            Pair("nav.auth.issuers.1.audience", "dev-fss:dusseldorf:k9-selvbetjening-oppslag"),
+            Pair("no.nav.security.jwt.issuers.1.issuer_name", "login-service-v1"),
+            Pair("no.nav.security.jwt.issuers.1.discoveryurl", "${mockOAuth2Server.wellKnownUrl("login-service-v1")}"),
+            Pair("no.nav.security.jwt.issuers.1.accepted_audience", "dev-fss:dusseldorf:k9-selvbetjening-oppslag"),
 
-            Pair("nav.auth.issuers.2.alias", "azure"),
-            Pair("nav.auth.issuers.2.discovery_endpoint", wireMockServer.getAzureV2WellKnownUrl()),
-            Pair("nav.auth.issuers.2.audience", "dev-fss:dusseldorf:k9-selvbetjening-oppslag"),
-            Pair("nav.auth.issuers.2.azure.required_roles", "access_as_application"),
+            Pair("no.nav.security.jwt.issuers.2.issuer_name", "azure"),
+            Pair("no.nav.security.jwt.issuers.2.discoveryurl", "${mockOAuth2Server.wellKnownUrl("azure")}"),
+            Pair("no.nav.security.jwt.issuers.2.accepted_audience", "dev-fss:dusseldorf:k9-selvbetjening-oppslag"),
 
             // Clients
             Pair("nav.auth.clients.0.alias", "tokenx"),
             Pair("nav.auth.clients.0.client_id", "k9-selvbetjening-oppslag"),
             Pair("nav.auth.clients.0.private_key_jwk", ClientCredentials.ClientC.privateKeyJwk),
-            Pair("nav.auth.clients.0.discovery_endpoint", wireMockServer.getTokendingsWellKnownUrl()),
+            Pair("nav.auth.clients.0.discovery_endpoint", wireMockServer!!.getTokendingsWellKnownUrl()),
             Pair("nav.auth.clients.1.alias", "azure"),
             Pair("nav.auth.clients.1.client_id", "k9-selvbetjening-oppslag"),
             Pair("nav.auth.clients.1.private_key_jwk", ClientCredentials.ClientA.privateKeyJwk),

--- a/src/test/kotlin/no/nav/k9/TestConfiguration.kt
+++ b/src/test/kotlin/no/nav/k9/TestConfiguration.kt
@@ -38,9 +38,16 @@ object TestConfiguration {
 
             Pair("nav.auth.issuers.0.alias", "login-service-v1"),
             Pair("nav.auth.issuers.0.discovery_endpoint", wireMockServer!!.getLoginServiceV1WellKnownUrl()),
+            Pair("nav.auth.issuers.0.audience", "dev-fss:dusseldorf:k9-selvbetjening-oppslag"),
 
             Pair("nav.auth.issuers.1.alias", "tokenx"),
             Pair("nav.auth.issuers.1.discovery_endpoint", wireMockServer.getTokendingsWellKnownUrl()),
+            Pair("nav.auth.issuers.1.audience", "dev-fss:dusseldorf:k9-selvbetjening-oppslag"),
+
+            Pair("nav.auth.issuers.2.alias", "azure"),
+            Pair("nav.auth.issuers.2.discovery_endpoint", wireMockServer.getAzureV2WellKnownUrl()),
+            Pair("nav.auth.issuers.2.audience", "dev-fss:dusseldorf:k9-selvbetjening-oppslag"),
+            Pair("nav.auth.issuers.2.azure.required_roles", "access_as_application"),
 
             // Clients
             Pair("nav.auth.clients.0.alias", "tokenx"),

--- a/src/test/kotlin/no/nav/k9/TestConfiguration.kt
+++ b/src/test/kotlin/no/nav/k9/TestConfiguration.kt
@@ -42,8 +42,8 @@ object TestConfiguration {
             Pair("no.nav.security.jwt.issuers.0.discoveryurl", "${mockOAuth2Server!!.wellKnownUrl("tokendings")}"),
             Pair("no.nav.security.jwt.issuers.0.accepted_audience", "dev-fss:dusseldorf:k9-selvbetjening-oppslag"),
 
-            Pair("no.nav.security.jwt.issuers.1.issuer_name", "login-service-v1"),
-            Pair("no.nav.security.jwt.issuers.1.discoveryurl", "${mockOAuth2Server.wellKnownUrl("login-service-v1")}"),
+            Pair("no.nav.security.jwt.issuers.1.issuer_name", "login-service-v2"),
+            Pair("no.nav.security.jwt.issuers.1.discoveryurl", "${mockOAuth2Server.wellKnownUrl("login-service-v2")}"),
             Pair("no.nav.security.jwt.issuers.1.accepted_audience", "dev-fss:dusseldorf:k9-selvbetjening-oppslag"),
 
             Pair("no.nav.security.jwt.issuers.2.issuer_name", "azure"),

--- a/src/test/kotlin/no/nav/k9/TokenUtils.kt
+++ b/src/test/kotlin/no/nav/k9/TokenUtils.kt
@@ -1,0 +1,14 @@
+package no.nav.k9
+
+import no.nav.security.mock.oauth2.MockOAuth2Server
+
+object TokenUtils {
+    fun MockOAuth2Server.hentToken(
+        subject: String,
+        issuerId: String = "tokendings",
+        audience: String = "dev-fss:dusseldorf:k9-selvbetjening-oppslag",
+        claims: Map<String, String> = mapOf("acr" to "Level4")
+    ): String {
+        return issueToken(issuerId = issuerId, subject = subject, audience = audience, claims = claims).serialize()
+    }
+}

--- a/src/test/kotlin/no/nav/k9/wiremocks/PDLHentIdenterBolkResponseTransformer.kt
+++ b/src/test/kotlin/no/nav/k9/wiremocks/PDLHentIdenterBolkResponseTransformer.kt
@@ -1,0 +1,92 @@
+package no.nav.k9.wiremocks
+
+import com.github.tomakehurst.wiremock.common.FileSource
+import com.github.tomakehurst.wiremock.extension.Parameters
+import com.github.tomakehurst.wiremock.extension.ResponseTransformer
+import com.github.tomakehurst.wiremock.http.Request
+import com.github.tomakehurst.wiremock.http.Response
+import no.nav.k9.PersonFødselsnummer.PERSON_1_MED_BARN
+import no.nav.k9.PersonFødselsnummer.PERSON_2_MED_BARN
+import no.nav.k9.PersonFødselsnummer.PERSON_3_MED_SKJERMET_BARN
+import no.nav.k9.PersonFødselsnummer.PERSON_4_MED_DØD_BARN
+import no.nav.siftilgangskontroll.core.pdl.utils.pdlHentIdenterBolkResponse
+import no.nav.siftilgangskontroll.pdl.generated.enums.IdentGruppe
+import no.nav.siftilgangskontroll.pdl.generated.hentidenterbolk.HentIdenterBolkResult
+import no.nav.siftilgangskontroll.pdl.generated.hentidenterbolk.IdentInformasjon
+import org.json.JSONObject
+import org.slf4j.LoggerFactory
+
+private val identerMap = mapOf(
+    PERSON_1_MED_BARN to HentIdenterBolkResult(
+        ident = PERSON_1_MED_BARN,
+        identer = listOf(IdentInformasjon(
+            ident = PERSON_1_MED_BARN,
+            gruppe = IdentGruppe.FOLKEREGISTERIDENT
+        )),
+        code = "ok"
+    ),
+
+    PERSON_2_MED_BARN to HentIdenterBolkResult(
+        ident = PERSON_2_MED_BARN,
+        identer = listOf(IdentInformasjon(
+            ident = PERSON_2_MED_BARN,
+            gruppe = IdentGruppe.FOLKEREGISTERIDENT
+        )),
+        code = "ok"
+    ),
+
+    PERSON_3_MED_SKJERMET_BARN to HentIdenterBolkResult(
+        ident = PERSON_3_MED_SKJERMET_BARN,
+        identer = listOf(IdentInformasjon(
+            ident = PERSON_3_MED_SKJERMET_BARN,
+            gruppe = IdentGruppe.FOLKEREGISTERIDENT
+        )),
+        code = "ok"
+    ),
+
+    PERSON_4_MED_DØD_BARN to HentIdenterBolkResult(
+        ident = PERSON_4_MED_DØD_BARN,
+        identer = listOf(IdentInformasjon(
+            ident = PERSON_4_MED_DØD_BARN,
+            gruppe = IdentGruppe.FOLKEREGISTERIDENT
+        )),
+        code = "ok"
+    ),
+)
+
+class PDLHentIdentBolkResponseTransformer : ResponseTransformer() {
+    private companion object {
+        val logger = LoggerFactory.getLogger(PDLHentPersonBolkResponseTransformer::class.java)
+    }
+
+    override fun transform(
+        request: Request?,
+        response: Response?,
+        files: FileSource?,
+        parameters: Parameters?,
+    ): Response {
+        val requestBody = JSONObject(request!!.body.decodeToString())
+        val identer: List<String> = requestBody.getJSONObject("variables").getJSONArray("identer").map {
+            it as String
+        }
+        logger.info("Hentet identer fra request: {}", identer)
+
+        return Response.Builder.like(response)
+            .body(getResponse(identer))
+            .build()
+    }
+
+    override fun getName(): String {
+        return "pdl-hent-identer-bolk"
+    }
+
+    override fun applyGlobally(): Boolean {
+        return false
+    }
+}
+
+private fun getResponse(identer: List<String>): String {
+    return pdlHentIdenterBolkResponse(identer.map {
+        identerMap[it]!!
+    })
+}

--- a/src/test/kotlin/no/nav/k9/wiremocks/WireMockStubs.kt
+++ b/src/test/kotlin/no/nav/k9/wiremocks/WireMockStubs.kt
@@ -22,6 +22,7 @@ internal fun WireMockBuilder.k9SelvbetjeningOppslagConfig() = wireMockConfigurat
         .extensions(PdlAktoerIdResponseTransformer())
         .extensions(PDLHentPersonBolkResponseTransformer())
         .extensions(PDLPersonResponseTransformer())
+        .extensions(PDLHentIdentBolkResponseTransformer())
         .extensions(ArbeidstakerResponseTransformer())
         .extensions(EnhetsregResponseTransformer())
         .extensions(BrregProxyV1ResponseTransformer())
@@ -43,6 +44,7 @@ internal fun WireMockServer.stubPDLRequest(pdlOperasjon: PdlOperasjon): WireMock
                         PdlOperasjon.HENT_PERSON -> "pdl-hent-person"
                         PdlOperasjon.HENT_PERSON_BOLK -> "pdl-hent-barn"
                         PdlOperasjon.HENT_IDENTER -> "pdl-hent-ident"
+                        PdlOperasjon.HENT_IDENTER_BOLK -> "pdl-hent-identer-bolk"
                     })
             )
     )


### PR DESCRIPTION
- Erstatter dusseldorf-ktot-auth med token-validation-ktor da det ikke fungerte med å konfigurere forskjellige endepunkt med forskjellige providers (issuer).

`/meg` oppsalg er konfigurert med tokenx/loginservice, mens` /systemkall/hent-identer` er konfigurert med azure.