### PR TITLE
Oppgraderer dusseldorf-ktor og dermed til Ktor 2.0.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,12 +1,12 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
-val dusseldorfKtorVersion = "3.1.6.8-5ba66a6"
+val dusseldorfKtorVersion = "3.2.0.2-b18c5fe"
 val ktorVersion = ext.get("ktorVersion").toString()
 val kotlinVersion = ext.get("kotlinVersion").toString()
-val graphqlKotlinClientVersion = "5.5.0"
-val sifTilgangskontrollVersion = "1-fdbcd61"
-val tokenSupportVersion = "2.0.21"
+val graphqlKotlinClientVersion = "6.0.0-alpha.4"
+val sifTilgangskontrollVersion = "1-2e642bd"
+val tokenSupportVersion = "2.1.0"
 val mockOauth2ServerVersion = "0.4.8"
 
 val mockkVersion = "1.12.4"
@@ -21,7 +21,7 @@ plugins {
 }
 
 buildscript {
-    apply("https://raw.githubusercontent.com/navikt/dusseldorf-ktor/5ba66a6899710ac2398ad497e2c8e22aa63062c8/gradle/dusseldorf-ktor.gradle.kts")
+    apply("https://raw.githubusercontent.com/navikt/dusseldorf-ktor/b18c5feeca2840e6812eb805d50937d7aa0aca6a/gradle/dusseldorf-ktor.gradle.kts")
 }
 
 dependencies {
@@ -36,7 +36,7 @@ dependencies {
         exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core")
     }
 
-    implementation ("no.nav.security:token-validation-ktor:$tokenSupportVersion")
+    implementation ("no.nav.security:token-validation-ktor-v2:$tokenSupportVersion")
     testImplementation ("no.nav.security:mock-oauth2-server:$mockOauth2ServerVersion")
 
     implementation("no.nav.sif.tilgangskontroll:spesification:$sifTilgangskontrollVersion")
@@ -61,8 +61,6 @@ dependencies {
 }
 
 repositories {
-    mavenLocal()
-
     maven {
         name = "GitHubPackages"
         url = uri("https://maven.pkg.github.com/navikt/dusseldorf-ktor")

--- a/src/main/kotlin/no/nav/k9/Configuration.kt
+++ b/src/main/kotlin/no/nav/k9/Configuration.kt
@@ -1,6 +1,6 @@
 package no.nav.k9
 
-import io.ktor.config.ApplicationConfig
+import io.ktor.server.config.ApplicationConfig
 import no.nav.helse.dusseldorf.ktor.core.getRequiredString
 import java.net.URI
 

--- a/src/main/kotlin/no/nav/k9/inngaende/CorrelationId.kt
+++ b/src/main/kotlin/no/nav/k9/inngaende/CorrelationId.kt
@@ -1,6 +1,6 @@
 package no.nav.k9.inngaende
 
-import io.ktor.application.ApplicationCall
+import io.ktor.server.application.ApplicationCall
 import io.ktor.http.HttpHeaders
 
 internal data class CorrelationId(internal val value: String)

--- a/src/main/kotlin/no/nav/k9/inngaende/oppslag/OppslagRoute.kt
+++ b/src/main/kotlin/no/nav/k9/inngaende/oppslag/OppslagRoute.kt
@@ -1,9 +1,9 @@
 package no.nav.k9.inngaende.oppslag
 
-import io.ktor.application.*
-import io.ktor.request.*
-import io.ktor.response.*
-import io.ktor.routing.*
+import io.ktor.server.application.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
 import kotlinx.coroutines.withContext
 import no.nav.helse.dusseldorf.ktor.auth.idToken
 import no.nav.helse.dusseldorf.ktor.core.*

--- a/src/main/kotlin/no/nav/k9/inngaende/oppslag/SystemOppslagRoute.kt
+++ b/src/main/kotlin/no/nav/k9/inngaende/oppslag/SystemOppslagRoute.kt
@@ -1,9 +1,9 @@
 package no.nav.k9.inngaende.oppslag
 
-import io.ktor.application.*
-import io.ktor.request.*
-import io.ktor.response.*
-import io.ktor.routing.*
+import io.ktor.server.application.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
 import kotlinx.coroutines.withContext
 import no.nav.helse.dusseldorf.ktor.auth.idToken
 import no.nav.k9.inngaende.RequestContextService

--- a/src/test/kotlin/no/nav/k9/ApplicationTest.kt
+++ b/src/test/kotlin/no/nav/k9/ApplicationTest.kt
@@ -1,14 +1,10 @@
 package no.nav.k9
 
 import com.typesafe.config.ConfigFactory
-import io.ktor.config.*
 import io.ktor.http.*
+import io.ktor.server.config.*
 import io.ktor.server.testing.*
 import io.prometheus.client.CollectorRegistry
-import no.nav.helse.dusseldorf.testsupport.jws.IDPorten
-import no.nav.helse.dusseldorf.testsupport.jws.LoginService
-import no.nav.helse.dusseldorf.testsupport.jws.Tokendings
-import no.nav.helse.dusseldorf.testsupport.jws.toDate
 import no.nav.helse.dusseldorf.testsupport.wiremock.WireMockBuilder
 import no.nav.k9.BarnFødselsnummer.BARN_TIL_PERSON_1
 import no.nav.k9.PersonFødselsnummer.DØD_PERSON
@@ -17,15 +13,11 @@ import no.nav.k9.PersonFødselsnummer.PERSON_2_MED_BARN
 import no.nav.k9.PersonFødselsnummer.PERSON_3_MED_SKJERMET_BARN
 import no.nav.k9.PersonFødselsnummer.PERSON_4_MED_DØD_BARN
 import no.nav.k9.PersonFødselsnummer.PERSON_MED_FLERE_ARBEIDSFORHOLD_PER_ARBEIDSGIVER
-import no.nav.k9.PersonFødselsnummer.PERSON_MED_FLERE_ROLLER_I_FORETAK
-import no.nav.k9.PersonFødselsnummer.PERSON_MED_FORETAK
 import no.nav.k9.PersonFødselsnummer.PERSON_MED_FRILANS_OPPDRAG
 import no.nav.k9.PersonFødselsnummer.PERSON_UNDER_MYNDIGHETS_ALDER
 import no.nav.k9.PersonFødselsnummer.PERSON_UTEN_ARBEIDSGIVER
 import no.nav.k9.PersonFødselsnummer.PERSON_UTEN_BARN
-import no.nav.k9.PersonFødselsnummer.PERSON_UTEN_FORETAK
 import no.nav.k9.TokenUtils.hentToken
-import no.nav.k9.inngaende.oppslag.MegUrlGenerator
 import no.nav.k9.wiremocks.*
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import no.nav.siftilgangskontroll.core.pdl.utils.PdlOperasjon
@@ -37,7 +29,6 @@ import org.junit.jupiter.api.Test
 import org.skyscreamer.jsonassert.JSONAssert
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import java.time.LocalDateTime
 import java.util.*
 
 class ApplicationTest {
@@ -224,21 +215,20 @@ class ApplicationTest {
                 assertEquals(HttpStatusCode.OK, response.status())
                 //language=json
                 val expectedResponse = """
-                    {
-                      "data": {
-                        "hentIdenterBolk": [
+                    [
+                      {
+                        "code": "ok",
+                        "ident": "$PERSON_1_MED_BARN",
+                        "identer": [
                           {
-                            "identer": [
-                              {
-                                "ident": "$PERSON_1_MED_BARN",
-                                "gruppe": "${IdentGruppe.FOLKEREGISTERIDENT}"
-                              }
-                            ]
+                            "ident": "$PERSON_1_MED_BARN",
+                            "gruppe": "${IdentGruppe.FOLKEREGISTERIDENT}"
                           }
                         ]
                       }
-                    }
+                    ]
                 """.trimIndent()
+                JSONAssert.assertEquals(expectedResponse, response.content!!, true)
             }
         }
     }

--- a/src/test/kotlin/no/nav/k9/ApplicationWithMocks.kt
+++ b/src/test/kotlin/no/nav/k9/ApplicationWithMocks.kt
@@ -1,6 +1,6 @@
 package no.nav.k9
 
-import io.ktor.server.testing.withApplication
+import io.ktor.server.testing.*
 import no.nav.helse.dusseldorf.testsupport.asArguments
 import no.nav.helse.dusseldorf.testsupport.wiremock.WireMockBuilder
 import no.nav.k9.wiremocks.*
@@ -41,7 +41,7 @@ class ApplicationWithMocks {
                 }
             })
 
-            withApplication { no.nav.k9.main(testArgs) }
+            testApplication { no.nav.k9.main(testArgs) }
         }
     }
 }


### PR DESCRIPTION
- Oppgraderer sif-tilgangskontroll med støtte for graphqlKotlinClientVersion 6.0.0-alpha.4.
- Oppgraderer graphql-kotlin-ktor-client til 6.0.0-alpha.4.
- Oppgradererer tokenSupportVersion til 2.1.0 med støtte for token-validation-ktor-v2.
- Refaktorerer JsonConverter.kt etter oppgradering til Ktor 2.0.