### PR TITLE
Støtter å hente alle ansettelsesperioder hos en arbeidsgiver.

### DIFF
--- a/src/main/kotlin/no/nav/k9/inngaende/oppslag/OppslagRoute.kt
+++ b/src/main/kotlin/no/nav/k9/inngaende/oppslag/OppslagRoute.kt
@@ -41,7 +41,7 @@ internal fun Route.OppslagRoute(
         } else {
             val idToken = call.idToken()
             val fraOgMedTilOgMed = call.hentFraOgMedTilOgMed()
-            val inkluderAlleAnsettelsesperiode = call.inkluderAlleAnsettelsesperioder()
+            val inkluderAlleAnsettelsesperioder = call.inkluderAlleAnsettelsesperioder()
 
             try {
                 val oppslagResultat: OppslagResultat = withContext(requestContextService.getCoroutineContext(
@@ -54,7 +54,7 @@ internal fun Route.OppslagRoute(
                         attributter = attributter,
                         fraOgMed = fraOgMedTilOgMed.first,
                         tilOgMed = fraOgMedTilOgMed.second,
-                        inkluderAlleAnsettelsesperiode,
+                        inkluderAlleAnsettelsesperioder = inkluderAlleAnsettelsesperioder,
                         ytelse = ytelse
                     )
                 }

--- a/src/main/kotlin/no/nav/k9/inngaende/oppslag/OppslagRoute.kt
+++ b/src/main/kotlin/no/nav/k9/inngaende/oppslag/OppslagRoute.kt
@@ -22,6 +22,7 @@ import java.time.ZoneId
 private const val ATTRIBUTT_QUERY_NAVN = "a"
 private const val FRA_OG_MED_QUERY_NAVN = "fom"
 private const val TIL_OG_MED_QUERY_NAVN = "tom"
+private const val INKLUDER_ALLE_ANSETTELSESPERIODER = "inkluderAlleAnsettelsesperioder"
 private const val ORGANISASJONER = "org"
 private val tomJson = JSONObject()
 
@@ -40,6 +41,7 @@ internal fun Route.OppslagRoute(
         } else {
             val idToken = call.idToken()
             val fraOgMedTilOgMed = call.hentFraOgMedTilOgMed()
+            val inkluderAlleAnsettelsesperiode = call.inkluderAlleAnsettelsesperioder()
 
             try {
                 val oppslagResultat: OppslagResultat = withContext(requestContextService.getCoroutineContext(
@@ -52,6 +54,7 @@ internal fun Route.OppslagRoute(
                         attributter = attributter,
                         fraOgMed = fraOgMedTilOgMed.first,
                         tilOgMed = fraOgMedTilOgMed.second,
+                        inkluderAlleAnsettelsesperiode,
                         ytelse = ytelse
                     )
                 }
@@ -133,6 +136,10 @@ private fun ApplicationCall.hentFraOgMedTilOgMed(): Pair<LocalDate, LocalDate> {
         first = if (fomQuery == null) iDag() else fomQuery.somLocalDate(FRA_OG_MED_QUERY_NAVN),
         second = if (tomQuery == null) iDag() else tomQuery.somLocalDate(TIL_OG_MED_QUERY_NAVN)
     )
+}
+
+private fun ApplicationCall.inkluderAlleAnsettelsesperioder(): Boolean {
+    return request.queryParameters[INKLUDER_ALLE_ANSETTELSESPERIODER]?.toBoolean() == true
 }
 
 private fun ApplicationCall.ytelse(): Ytelse = ytelseFraHeader()

--- a/src/main/kotlin/no/nav/k9/inngaende/oppslag/OppslagService.kt
+++ b/src/main/kotlin/no/nav/k9/inngaende/oppslag/OppslagService.kt
@@ -46,11 +46,11 @@ internal class OppslagService(
         attributter: Set<Attributt>,
         fraOgMed: LocalDate,
         tilOgMed: LocalDate,
-        inkluderAlleAnsettelsesperiode: Boolean,
+        inkluderAlleAnsettelsesperioder: Boolean,
         ytelse: Ytelse,
     ): OppslagResultat {
 
-        val arbeidsgivere = arbeidsgiverOgArbeidstakerRegisterGateway.arbeidsgivere(ident, fraOgMed, tilOgMed, inkluderAlleAnsettelsesperiode, attributter)
+        val arbeidsgivere = arbeidsgiverOgArbeidstakerRegisterGateway.arbeidsgivere(ident, fraOgMed, tilOgMed, inkluderAlleAnsettelsesperioder, attributter)
 
         val meg = megOppslag.meg(
             ident = ident,

--- a/src/main/kotlin/no/nav/k9/inngaende/oppslag/OppslagService.kt
+++ b/src/main/kotlin/no/nav/k9/inngaende/oppslag/OppslagService.kt
@@ -46,10 +46,11 @@ internal class OppslagService(
         attributter: Set<Attributt>,
         fraOgMed: LocalDate,
         tilOgMed: LocalDate,
+        inkluderAlleAnsettelsesperiode: Boolean,
         ytelse: Ytelse,
     ): OppslagResultat {
 
-        val arbeidsgivere = arbeidsgiverOgArbeidstakerRegisterGateway.arbeidsgivere(ident, fraOgMed, tilOgMed, attributter)
+        val arbeidsgivere = arbeidsgiverOgArbeidstakerRegisterGateway.arbeidsgivere(ident, fraOgMed, tilOgMed, inkluderAlleAnsettelsesperiode, attributter)
 
         val meg = megOppslag.meg(
             ident = ident,
@@ -88,7 +89,7 @@ internal class OppslagService(
         val arbeidsgivere = Arbeidsgivere(
             organisasjoner = organisasjoner
                 .map { OrganisasjonArbeidsgivere(it) }
-                .toSet()
+                .toList()
         )
 
         return OppslagResultat(

--- a/src/main/kotlin/no/nav/k9/utgaende/gateway/ArbeidsgiverOgArbeidstakerRegisterGateway.kt
+++ b/src/main/kotlin/no/nav/k9/utgaende/gateway/ArbeidsgiverOgArbeidstakerRegisterGateway.kt
@@ -24,13 +24,15 @@ internal class ArbeidsgiverOgArbeidstakerRegisterGateway(
         ident: Ident,
         fraOgMed: LocalDate,
         tilOgMed: LocalDate,
+        inkluderAlleAnsettelsesperiode: Boolean,
         attributter: Set<Attributt>
     ): Arbeidsgivere? {
         if (!attributter.any { it in støttedeAttributter }) return null
         return arbeidstakerOgArbeidstakerRegisterV2.arbeidsgivere(
             ident = ident,
             fraOgMed = fraOgMed,
-            tilOgMed = tilOgMed
+            tilOgMed = tilOgMed,
+            inkluderAlleAnsettelsesperiode
         )
     }
 }

--- a/src/main/kotlin/no/nav/k9/utgaende/gateway/ArbeidsgiverOgArbeidstakerRegisterGateway.kt
+++ b/src/main/kotlin/no/nav/k9/utgaende/gateway/ArbeidsgiverOgArbeidstakerRegisterGateway.kt
@@ -24,7 +24,7 @@ internal class ArbeidsgiverOgArbeidstakerRegisterGateway(
         ident: Ident,
         fraOgMed: LocalDate,
         tilOgMed: LocalDate,
-        inkluderAlleAnsettelsesperiode: Boolean,
+        inkluderAlleAnsettelsesperioder: Boolean,
         attributter: Set<Attributt>
     ): Arbeidsgivere? {
         if (!attributter.any { it in støttedeAttributter }) return null
@@ -32,7 +32,7 @@ internal class ArbeidsgiverOgArbeidstakerRegisterGateway(
             ident = ident,
             fraOgMed = fraOgMed,
             tilOgMed = tilOgMed,
-            inkluderAlleAnsettelsesperiode
+            inkluderAlleAnsettelsesperioder
         )
     }
 }

--- a/src/main/kotlin/no/nav/k9/utgaende/rest/Arbeidsgivere.kt
+++ b/src/main/kotlin/no/nav/k9/utgaende/rest/Arbeidsgivere.kt
@@ -4,7 +4,7 @@ import no.nav.k9.utgaende.rest.aaregv2.TypeArbeidssted
 import java.time.LocalDate
 
 internal data class Arbeidsgivere(
-    internal val organisasjoner: Set<OrganisasjonArbeidsgivere>,
+    internal val organisasjoner: List<OrganisasjonArbeidsgivere>,
     internal val privateArbeidsgivere: Set<PrivatArbeidsgiver> = emptySet(),
     internal val frilansoppdrag: Set<Frilansoppdrag> = emptySet()
 )

--- a/src/main/kotlin/no/nav/k9/utgaende/rest/aaregv2/ArbeidsgiverOgArbeidstakerRegisterV2.kt
+++ b/src/main/kotlin/no/nav/k9/utgaende/rest/aaregv2/ArbeidsgiverOgArbeidstakerRegisterV2.kt
@@ -43,7 +43,8 @@ internal class ArbeidsgiverOgArbeidstakerRegisterV2 (
     internal suspend fun arbeidsgivere(
         ident: Ident,
         fraOgMed: LocalDate,
-        tilOgMed: LocalDate
+        tilOgMed: LocalDate,
+        inkluderAlleAnsettelsesperiode: Boolean
     ) : Arbeidsgivere{
         val exchangeToken = cachedAccessTokenClient.getAccessToken(
             scopes = setOf(aaregTokenxAudience),
@@ -86,13 +87,13 @@ internal class ArbeidsgiverOgArbeidstakerRegisterV2 (
         logger.logResponse(json)
 
         if (json.isEmpty) return Arbeidsgivere(
-            organisasjoner = emptySet(),
+            organisasjoner = emptyList(),
             privateArbeidsgivere = emptySet(),
             frilansoppdrag = emptySet()
         )
 
         return Arbeidsgivere(
-            organisasjoner = json.hentOrganisasjonerV2(fraOgMed, tilOgMed),
+            organisasjoner = json.hentOrganisasjonerV2(fraOgMed, tilOgMed, inkluderAlleAnsettelsesperiode),
             privateArbeidsgivere = json.hentPrivateArbeidsgivereV2(fraOgMed, tilOgMed),
             frilansoppdrag = json.hentFrilansoppdragV2(fraOgMed, tilOgMed)
         )

--- a/src/main/kotlin/no/nav/k9/utgaende/rest/aaregv2/ArbeidsgiverOgArbeidstakerRegisterV2.kt
+++ b/src/main/kotlin/no/nav/k9/utgaende/rest/aaregv2/ArbeidsgiverOgArbeidstakerRegisterV2.kt
@@ -44,7 +44,7 @@ internal class ArbeidsgiverOgArbeidstakerRegisterV2 (
         ident: Ident,
         fraOgMed: LocalDate,
         tilOgMed: LocalDate,
-        inkluderAlleAnsettelsesperiode: Boolean
+        inkluderAlleAnsettelsesperioder: Boolean
     ) : Arbeidsgivere{
         val exchangeToken = cachedAccessTokenClient.getAccessToken(
             scopes = setOf(aaregTokenxAudience),
@@ -93,7 +93,7 @@ internal class ArbeidsgiverOgArbeidstakerRegisterV2 (
         )
 
         return Arbeidsgivere(
-            organisasjoner = json.hentOrganisasjonerV2(fraOgMed, tilOgMed, inkluderAlleAnsettelsesperiode),
+            organisasjoner = json.hentOrganisasjonerV2(fraOgMed, tilOgMed, inkluderAlleAnsettelsesperioder),
             privateArbeidsgivere = json.hentPrivateArbeidsgivereV2(fraOgMed, tilOgMed),
             frilansoppdrag = json.hentFrilansoppdragV2(fraOgMed, tilOgMed)
         )

--- a/src/main/kotlin/no/nav/k9/utgaende/rest/aaregv2/JsonUtils.kt
+++ b/src/main/kotlin/no/nav/k9/utgaende/rest/aaregv2/JsonUtils.kt
@@ -9,7 +9,7 @@ import org.json.JSONArray
 import org.json.JSONObject
 import java.time.LocalDate
 
-internal fun JSONArray.hentOrganisasjonerV2(fraOgMed: LocalDate, tilOgMed: LocalDate, inkluderAlleAnsettelsesperiode: Boolean): List<OrganisasjonArbeidsgivere> {
+internal fun JSONArray.hentOrganisasjonerV2(fraOgMed: LocalDate, tilOgMed: LocalDate, inkluderAlleAnsettelsesperioder: Boolean): List<OrganisasjonArbeidsgivere> {
     val alleArbeidsforhold: Sequence<OrganisasjonArbeidsgivere> = hentArbeidsgivereMedAnsettelseperiodeV2()
         .filterNot { it.erFrilansaktivitet() }
         .filter { it.arbeidstedErUnderenhet() }
@@ -26,7 +26,7 @@ internal fun JSONArray.hentOrganisasjonerV2(fraOgMed: LocalDate, tilOgMed: Local
         .sortedBy { it.ansattFom }
 
     return when {
-        inkluderAlleAnsettelsesperiode -> alleArbeidsforhold.toList()
+        inkluderAlleAnsettelsesperioder -> alleArbeidsforhold.toList()
         else -> alleArbeidsforhold.distinctBy { it.organisasjonsnummer }.toList()
     }
 }

--- a/src/main/kotlin/no/nav/k9/utgaende/rest/aaregv2/JsonUtils.kt
+++ b/src/main/kotlin/no/nav/k9/utgaende/rest/aaregv2/JsonUtils.kt
@@ -9,8 +9,8 @@ import org.json.JSONArray
 import org.json.JSONObject
 import java.time.LocalDate
 
-internal fun JSONArray.hentOrganisasjonerV2(fraOgMed: LocalDate, tilOgMed: LocalDate): Set<OrganisasjonArbeidsgivere> =
-    hentArbeidsgivereMedAnsettelseperiodeV2()
+internal fun JSONArray.hentOrganisasjonerV2(fraOgMed: LocalDate, tilOgMed: LocalDate, inkluderAlleAnsettelsesperiode: Boolean): List<OrganisasjonArbeidsgivere> {
+    val alleArbeidsforhold: Sequence<OrganisasjonArbeidsgivere> = hentArbeidsgivereMedAnsettelseperiodeV2()
         .filterNot { it.erFrilansaktivitet() }
         .filter { it.arbeidstedErUnderenhet() }
         .map { ansettelsesforhold ->
@@ -24,8 +24,13 @@ internal fun JSONArray.hentOrganisasjonerV2(fraOgMed: LocalDate, tilOgMed: Local
         }
         .filter { erAnsattIPerioden(it.ansattFom, it.ansattTom, fraOgMed, tilOgMed) }
         .sortedBy { it.ansattFom }
-        .distinctBy { it.organisasjonsnummer }
-        .toSet()
+
+    return when {
+        inkluderAlleAnsettelsesperiode -> alleArbeidsforhold.toList()
+        else -> alleArbeidsforhold.distinctBy { it.organisasjonsnummer }.toList()
+    }
+}
+
 
 internal fun JSONArray.hentFrilansoppdragV2(fraOgMed: LocalDate, tilOgMed: LocalDate): Set<Frilansoppdrag> =
     hentArbeidsgivereMedAnsettelseperiodeV2()

--- a/src/test/kotlin/no/nav/k9/wiremocks/ArbeidstakerResponseV2Transformer.kt
+++ b/src/test/kotlin/no/nav/k9/wiremocks/ArbeidstakerResponseV2Transformer.kt
@@ -30,6 +30,7 @@ class ArbeidstakerResponseV2Transformer : ResponseTransformerV2 {
 private fun getResponse(navIdent: String) : String {
     val jsonRespons = JSONArray()
     val ansettelsesperiode = JSONObject().apply { put("startdato","2020-01-01"); put("sluttdato", "2029-02-28") }
+    val ansettelsesperiode2 = JSONObject().apply { put("startdato","2015-01-01"); put("sluttdato", "2019-12-31") }
     val identerOrg = JSONArray().apply { put(JSONObject().apply { put("ident", "123456789"); put("type", "ORGANISASJONSNUMMER") }) }
     val identerFolkeregistrert = JSONArray().apply { put(JSONObject().apply { put("ident", "28837996386"); put("type", "FOLKEREGISTERIDENT") }) }
     val arbeidsstedUnderenhet = JSONObject().apply { put("type", "Underenhet"); put("identer", identerOrg) }
@@ -76,11 +77,17 @@ private fun getResponse(navIdent: String) : String {
             }.toString()
         }
         PersonFødselsnummer.PERSON_MED_FLERE_ARBEIDSFORHOLD_PER_ARBEIDSGIVER -> {
+            val organisasjonMedToAnsettelsesperioder = JSONObject().apply {
+                put("type", JSONObject().apply { put("kode", "ordinaertArbeidsforhold") })
+                put("ansettelsesperiode", ansettelsesperiode2)
+                put("arbeidssted", arbeidsstedUnderenhet)
+            }
+
             return jsonRespons.apply {
                 put(privatArbeidsgiverPerson)
                 put(privatArbeidsgiverPerson)
                 put(organisasjon)
-                put(organisasjon)
+                put(organisasjonMedToAnsettelsesperioder)
             }.toString()
         }
         else -> {


### PR DESCRIPTION
Legger til query parameter (inkluderAlleAnsettelsesperioder) på /meg oppslag for å kunne toggle det på.
Default er dette false, og returnerer kun første ansettelsesperiode som matcher søkt periode.