### PR TITLE
Erstatt fiktive fødselsnummer med syntetisk fnr

### DIFF
--- a/src/test/kotlin/no/nav/k9/wiremocks/ArbeidstakerResponseTransformer.kt
+++ b/src/test/kotlin/no/nav/k9/wiremocks/ArbeidstakerResponseTransformer.kt
@@ -68,7 +68,7 @@ private fun getResponse(navIdent: String) : String {
                       }
                     },
                     "arbeidsgiver":{
-                       "offentligIdent":"01017000299",
+                       "offentligIdent":"23500180528",
                        "aktoerId":"2142740417741",
                        "type":"Person"
                     }
@@ -83,7 +83,7 @@ private fun getResponse(navIdent: String) : String {
                       }
                     },
                     "arbeidsgiver":{
-                       "offentligIdent":"01017000299",
+                       "offentligIdent":"23500180528",
                        "aktoerId":"2142740417741",
                        "type":"Person"
                     }
@@ -155,7 +155,7 @@ private fun getResponse(navIdent: String) : String {
                    }
                 },
                 "arbeidsgiver":{
-                   "offentligIdent":"01017000299",
+                   "offentligIdent":"23500180528",
                    "aktoerId":"2142740417741",
                    "type":"Person"
                 },


### PR DESCRIPTION
Erstatter gamle fiktive FNR brukt i tester med nytt fiktivt syntetiske personnummer (23500180528) som automatisk ignoreres av sif-code-scan.

Relatert til navikt/sif-gha-workflows#280